### PR TITLE
DTS endpoint generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This will create a new timestamped directory in the `public/data` folder, contai
 
 In order to set up a server with DTS, you may follow the instructions at the [DTSflat-server](https://github.com/robcast/dtsflat-server) repo. Just copy your new DTS data directory (`public/data/dts-data_YYYY-MM-DD_hh:mm:ss`) to the `DTS_DATA_DIR` location you set in `.env` when following that repo.
 
-If you wish to serve the DTS endpoints from the same server as the critical edition, you will need to modify the Nginx configuration. For example, our development server uses the following configuration to serve the DTS endpoints on port 3333, pulling data from the `/var/www/dts-data` directory.
+If you wish to serve the DTS endpoints from the same server as the critical edition, you may need to modify the Nginx configuration. For example, our development server uses the following configuration to serve the DTS endpoints on port 3333, pulling data from the `/var/www/dts-data` directory. It is appended as a second `server` block, in addition to the one that serves the critical edition static site.
 
 <details>
 <summary>Nginx configuration for port 3333</summary>
@@ -167,7 +167,7 @@ map $arg_level $level_path {
 
 </details>
 
-With this configuration, when you are ready to regenerate the DTS data, you can run the script and then replace the contents of `/var/www/dts-data` on the server with the contents of the latest `public/data/dts-data_YYYY-MM-DD_hh:mm:ss` directory. For example, with rsync, from the project root directory on your local machine, the command might look something like this with [rsync](https://www.digitalocean.com/community/tutorials/how-to-use-rsync-to-sync-local-and-remote-directories):
+With this configuration, when you are ready to regenerate the DTS data, you can run the script and then replace the contents of `/var/www/dts-data` on the server with the contents of the latest `public/data/dts-data_YYYY-MM-DD_hh:mm:ss` directory. For example, from the project root directory on your local machine, the command might look something like this with [rsync](https://www.digitalocean.com/community/tutorials/how-to-use-rsync-to-sync-local-and-remote-directories):
 
 ```sh
 rsync -ar --delete public/data/dts-data_YYYY-MM-DD_hh:mm:ss/. user@server:/var/www/dts-data

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This will create a new timestamped directory in the `public/data` folder, contai
 
 In order to set up a server with DTS, you may follow the instructions at the [DTSflat-server](https://github.com/robcast/dtsflat-server) repo. Just copy your new DTS data directory (`public/data/dts-data_YYYY-MM-DD_hh:mm:ss`) to the `DTS_DATA_DIR` location you set in `.env` when following that repo.
 
-If you wish to serve the DTS endpoints from the same server as the critical edition, you may need to modify the Nginx configuration. For example, our development server uses the following configuration to serve the DTS endpoints from `/dts`, pulling data from the `/var/www/dts-data` directory. It is appended as a second `location` block, in addition to block one for `/` that serves the critical edition static site from the `/var/www/html` directory.
+If you wish to serve the DTS endpoints from the same server as the critical edition, you may need to modify the Nginx configuration. For example, our development server uses the following configuration to serve the DTS endpoints from `/dts`, pulling data from the `/var/www/dts-data` directory. It is appended as a second `location` block, in addition to the block for `/` that serves the critical edition static site from the `/var/www/html` directory.
 
 To view this configuration, view [example.nginx.conf](script/example.nginx.conf) in the `/script` directory.
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,98 @@ For Stemmaweb, the final argument should be something like `edition@monitor.stem
 
 **On the server:**
 
-```rm -rf build
+```sh
+rm -rf build
 unzip <buildID>
 rm -rf www/*
 cp -r build/* www
+```
+
+## DTS support
+
+To support [DTS](https://distributed-text-services.github.io/specifications/) navigation and document endpoints using [DTSflat-server](https://github.com/robcast/dtsflat-server) and [Simple tei2dtsflat](https://github.com/robcast/simple-tei2dtsflat), follow the following instructions.
+
+### Dependency Installation
+
+Navigate to the `/script` directory and clone the simple-tei2dtsflat repo.
+
+```sh
+cd script
+git clone https://github.com/performant-software/simple-tei2dtsflat.git
+cd ..
+```
+
+### DTS Data Generation
+
+From the project root directory, run the following command:
+
+```sh
+node script/generateDtsData.js
+```
+
+This will create a new timestamped directory in the `public/data` folder, containing a DTSFlat file structure of all manuscripts and the lemma edition.
+
+### DTS Endpoint Nginx Configuration
+
+In order to set up a server with DTS, you may follow the instructions at the [DTSflat-server](https://github.com/robcast/dtsflat-server) repo. Just copy your new DTS data directory (`public/data/dts-data_YYYY-MM-DD_hh:mm:ss`) to the `DTS_DATA_DIR` location you set in `.env` when following that repo.
+
+If you wish to serve the DTS endpoints from the same server as the critical edition, you will need to modify the Nginx configuration. For example, our development server uses the following configuration to serve the DTS endpoints on port 3333, pulling data from the `/var/www/dts-data` directory.
+
+<details>
+<summary>Nginx configuration for port 3333</summary>
+
+```conf
+server {
+  listen       3333 default_server;
+  listen  [::]:3333 default_server;
+
+  server_name _;
+
+  access_log /var/log/nginx/access-dts.log;
+  error_log /var/log/nginx/error-dts.log debug;
+
+  # add CORS header to all responses
+  add_header Access-Control-Allow-Origin "*";
+
+  # base for all try_files
+  root /var/www/dts-data;
+
+  # map DTS documents endpoint to files
+  location /dts/documents {
+      default_type text/xml;
+      # second try works with empty $arg_ref but fails with invalid $arg_ref
+      try_files /$arg_id/$arg_ref/tei-frag.xml /$arg_id$arg_ref/tei-full.xml =400;
+  }
+
+  # map DTS navigation endpoint to files
+  location /dts/navigation {
+      default_type application/json;
+      try_files /$arg_id$ref_path$level_path/dts-nav.json =400;
+  }
+}
+
+
+map $arg_ref $ref_path {
+  default "";
+  ~(.+) /$1;
+}
+
+map $arg_level $level_path {
+  default "";
+  ~(.+) /$1;
+}
+```
+
+</details>
+
+With this configuration, when you are ready to regenerate the DTS data, you can run the script and then replace the contents of `/var/www/dts-data` on the server with the contents of the latest `public/data/dts-data_YYYY-MM-DD_hh:mm:ss` directory. For example, with rsync, from the project root directory on your local machine, the command might look something like this with [rsync](https://www.digitalocean.com/community/tutorials/how-to-use-rsync-to-sync-local-and-remote-directories):
+
+```sh
+rsync -ar --delete public/data/dts-data_YYYY-MM-DD_hh:mm:ss/. user@server:/var/www/dts-data
+```
+
+We run it with the following additional options in order to ensure MacOS Spotlight `.DS_Store` files are not included:
+
+```sh
+rsync -arv --exclude=.DS_Store --delete-excluded --delete public/data/dts-data_YYYY-MM-DD_hh:mm:ss/. user@server:/var/www/dts-data
 ```

--- a/README.md
+++ b/README.md
@@ -118,54 +118,9 @@ This will create a new timestamped directory in the `public/data` folder, contai
 
 In order to set up a server with DTS, you may follow the instructions at the [DTSflat-server](https://github.com/robcast/dtsflat-server) repo. Just copy your new DTS data directory (`public/data/dts-data_YYYY-MM-DD_hh:mm:ss`) to the `DTS_DATA_DIR` location you set in `.env` when following that repo.
 
-If you wish to serve the DTS endpoints from the same server as the critical edition, you may need to modify the Nginx configuration. For example, our development server uses the following configuration to serve the DTS endpoints on port 3333, pulling data from the `/var/www/dts-data` directory. It is appended as a second `server` block, in addition to the one that serves the critical edition static site.
+If you wish to serve the DTS endpoints from the same server as the critical edition, you may need to modify the Nginx configuration. For example, our development server uses the following configuration to serve the DTS endpoints from `/dts`, pulling data from the `/var/www/dts-data` directory. It is appended as a second `location` block, in addition to block one for `/` that serves the critical edition static site from the `/var/www/html` directory.
 
-<details>
-<summary>Nginx configuration for port 3333</summary>
-
-```conf
-server {
-  listen       3333 default_server;
-  listen  [::]:3333 default_server;
-
-  server_name _;
-
-  access_log /var/log/nginx/access-dts.log;
-  error_log /var/log/nginx/error-dts.log debug;
-
-  # add CORS header to all responses
-  add_header Access-Control-Allow-Origin "*";
-
-  # base for all try_files
-  root /var/www/dts-data;
-
-  # map DTS documents endpoint to files
-  location /dts/documents {
-      default_type text/xml;
-      # second try works with empty $arg_ref but fails with invalid $arg_ref
-      try_files /$arg_id/$arg_ref/tei-frag.xml /$arg_id$arg_ref/tei-full.xml =400;
-  }
-
-  # map DTS navigation endpoint to files
-  location /dts/navigation {
-      default_type application/json;
-      try_files /$arg_id$ref_path$level_path/dts-nav.json =400;
-  }
-}
-
-
-map $arg_ref $ref_path {
-  default "";
-  ~(.+) /$1;
-}
-
-map $arg_level $level_path {
-  default "";
-  ~(.+) /$1;
-}
-```
-
-</details>
+To view this configuration, view [example.nginx.conf](script/example.nginx.conf) in the `/script` directory.
 
 With this configuration, when you are ready to regenerate the DTS data, you can run the script and then replace the contents of `/var/www/dts-data` on the server with the contents of the latest `public/data/dts-data_YYYY-MM-DD_hh:mm:ss` directory. For example, from the project root directory on your local machine, the command might look something like this with [rsync](https://www.digitalocean.com/community/tutorials/how-to-use-rsync-to-sync-local-and-remote-directories):
 

--- a/public/images/mss/Bz430/Bz430.tei.xml
+++ b/public/images/mss/Bz430/Bz430.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/Bz449/Bz449.tei.xml
+++ b/public/images/mss/Bz449/Bz449.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/Bz644/Bz644.tei.xml
+++ b/public/images/mss/Bz644/Bz644.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/L5260/L5260.tei.xml
+++ b/public/images/mss/L5260/L5260.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M1731/M1731.tei.xml
+++ b/public/images/mss/M1731/M1731.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M1767/M1767.tei.xml
+++ b/public/images/mss/M1767/M1767.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M1768/M1768.tei.xml
+++ b/public/images/mss/M1768/M1768.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M1769/M1769.tei.xml
+++ b/public/images/mss/M1769/M1769.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M1775/M1775.tei.xml
+++ b/public/images/mss/M1775/M1775.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M1896/M1896.tei.xml
+++ b/public/images/mss/M1896/M1896.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M2644/M2644.tei.xml
+++ b/public/images/mss/M2644/M2644.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M2855/M2855.tei.xml
+++ b/public/images/mss/M2855/M2855.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M2899/M2899.tei.xml
+++ b/public/images/mss/M2899/M2899.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M3071/M3071.tei.xml
+++ b/public/images/mss/M3071/M3071.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M3380/M3380.tei.xml
+++ b/public/images/mss/M3380/M3380.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M3519/M3519.tei.xml
+++ b/public/images/mss/M3519/M3519.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M3520/M3520.tei.xml
+++ b/public/images/mss/M3520/M3520.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M5587/M5587.tei.xml
+++ b/public/images/mss/M5587/M5587.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M6605/M6605.tei.xml
+++ b/public/images/mss/M6605/M6605.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M6686/M6686.tei.xml
+++ b/public/images/mss/M6686/M6686.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/M8232/M8232.tei.xml
+++ b/public/images/mss/M8232/M8232.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/Ox-e.32/Ox-e.32.tei.xml
+++ b/public/images/mss/Ox-e.32/Ox-e.32.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/V901/V901.tei.xml
+++ b/public/images/mss/V901/V901.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/V913/V913.tei.xml
+++ b/public/images/mss/V913/V913.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/V917/V917.tei.xml
+++ b/public/images/mss/V917/V917.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/W243/W243.tei.xml
+++ b/public/images/mss/W243/W243.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/W246/W246.tei.xml
+++ b/public/images/mss/W246/W246.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/public/images/mss/W574/W574.tei.xml
+++ b/public/images/mss/W574/W574.tei.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>

--- a/script/example.nginx.conf
+++ b/script/example.nginx.conf
@@ -1,0 +1,48 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    root /var/www/html;
+
+    index index.html index.htm index.nginx-debian.html;
+
+    server_name _;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    location /dts {
+        access_log /var/log/nginx/access-dts.log;
+        error_log /var/log/nginx/error-dts.log debug;
+
+        # add CORS header to all responses
+        add_header Access-Control-Allow-Origin "*";
+
+        # base for all try_files
+        root /var/www/dts-data;
+
+        # map DTS documents endpoint to files
+        location /dts/documents {
+            default_type text/xml;
+            # second try works with empty $arg_ref but fails with invalid $arg_ref
+            try_files /$arg_id/$arg_ref/tei-frag.xml /$arg_id$arg_ref/tei-full.xml =400;
+        }
+
+        # map DTS navigation endpoint to files
+        location /dts/navigation {
+            default_type application/json;
+            try_files /$arg_id$ref_path$level_path/dts-nav.json =400;
+        }
+    }
+}
+
+map $arg_ref $ref_path {
+    default "";
+    ~(.+) /$1;
+}
+
+map $arg_level $level_path {
+    default "";
+    ~(.+) /$1;
+}

--- a/script/generateDtsData.js
+++ b/script/generateDtsData.js
@@ -1,0 +1,8 @@
+const { execSync } = require("child_process");
+const moment = require("moment");
+
+const timestamp = moment().format("YYYY-MM-DD_hh:mm:ss");
+
+execSync(`node script/generateLemmaTei.js ${timestamp}`, { stdio: "inherit" });
+
+execSync(`node script/generateDtsStructure.js ${timestamp}`, { stdio: "inherit" });

--- a/script/generateDtsStructure.js
+++ b/script/generateDtsStructure.js
@@ -18,7 +18,6 @@ async function generateDtsStructure(timestamp) {
             return Promise.all(manuscriptFiles.map(async (file) => {
                 // process every xml file in each manuscript folder
                 if (path.extname(file).toLowerCase().includes("xml")) {
-                    // console.log(`opening ${path.resolve(dirPath, file)}`);
                     await teiToDtsFlat(
                         path.resolve(dirPath, file),
                         // use manuscript name (directory name) as id
@@ -35,9 +34,10 @@ async function generateDtsStructure(timestamp) {
     }));
 
     function teiToDtsFlat(filename, id, mode) {
+        // run the tei2dtsflat script on the file, then resolve promise on exit
         return new Promise((resolve, reject) => {
             const proc = spawn("python3", [
-                `script/vendor/simple-tei2dtsflat/tei2dtsflat.py`,
+                `script/simple-tei2dtsflat/tei2dtsflat.py`,
                 "-b", `public/data/dts-data_${timestamp}`, // Base dir to save structure
                 "-m", mode, // element by which to split tei (pb or div)
                 "-i", id, // ID for output XML
@@ -54,11 +54,7 @@ async function generateDtsStructure(timestamp) {
                 console.log(error);
                 reject(error);
             });
-            // proc.on("exit", async (code) => {
-            //     console.log(`exited ${filename} with code ${code}`);
-            // });
             proc.on("close", async (code) => {
-                // console.log(`closed ${filename} with code ${code}`);
                 if (filename === lemmaFile) {
                     // delete temp dir
                     await fs.rm(`public/data/dts-xml_${timestamp}`, {

--- a/script/generateDtsStructure.js
+++ b/script/generateDtsStructure.js
@@ -1,0 +1,81 @@
+const { spawn } = require("child_process");
+const fs = require("fs/promises");
+const path = require("path");
+const moment = require("moment");
+
+async function generateDtsStructure(timestamp) {
+    // use generated TEI to build lemma DTS
+    const lemmaFile = `public/data/dts-xml_${timestamp}/lemma.tei.xml`;
+    await teiToDtsFlat(lemmaFile, "lemma", "div");
+
+    // build manuscript DTS
+    manuscriptsDirs = await fs.readdir("public/images/mss");
+    await Promise.all(manuscriptsDirs.map(async (dir) => {
+        const dirPath = path.resolve("public/images/mss", dir);
+        const stat = await fs.stat(dirPath);
+        if (stat.isDirectory()) {
+            manuscriptFiles = await fs.readdir(dirPath);
+            return Promise.all(manuscriptFiles.map(async (file) => {
+                // process every xml file in each manuscript folder
+                if (path.extname(file).toLowerCase().includes("xml")) {
+                    // console.log(`opening ${path.resolve(dirPath, file)}`);
+                    await teiToDtsFlat(
+                        path.resolve(dirPath, file),
+                        // use manuscript name (directory name) as id
+                        dirPath.split(path.sep).pop(),
+                        // use page break (pb) mode
+                        "pb",
+                    );
+                }
+                return Promise.resolve();
+            }));
+        } else {
+            return Promise.resolve();
+        }
+    }));
+
+    function teiToDtsFlat(filename, id, mode) {
+        return new Promise((resolve, reject) => {
+            const proc = spawn("python3", [
+                `script/vendor/simple-tei2dtsflat/tei2dtsflat.py`,
+                "-b", `public/data/dts-data_${timestamp}`, // Base dir to save structure
+                "-m", mode, // element by which to split tei (pb or div)
+                "-i", id, // ID for output XML
+                "--gen-id-prefix", `${id}_`, // prefix for generated ids
+                filename, // Input file
+            ]);
+            proc.stdout.on("data", (data) => {
+                console.log(data.toString());
+            });
+            proc.stderr.on("data", (data) => {
+                console.log(data.toString());
+            });
+            proc.on("error", async (error) => {
+                console.log(error);
+                reject(error);
+            });
+            // proc.on("exit", async (code) => {
+            //     console.log(`exited ${filename} with code ${code}`);
+            // });
+            proc.on("close", async (code) => {
+                // console.log(`closed ${filename} with code ${code}`);
+                if (filename === lemmaFile) {
+                    // delete temp dir
+                    await fs.rm(`public/data/dts-xml_${timestamp}`, {
+                        recursive: true,
+                        force: true,
+                    });
+                }
+                resolve(code);
+            });
+        });
+    }
+}
+
+(async () => {
+    const timestamp = process.argv[2];
+    await generateDtsStructure(timestamp);
+
+    const endTime = moment();
+    console.log("Done!", endTime.format("hh:mm:ss"));
+})();

--- a/script/generateLemmaTei.js
+++ b/script/generateLemmaTei.js
@@ -1,0 +1,409 @@
+const fs = require("fs");
+const axios = require("axios");
+const moment = require("moment");
+
+// Generate TEI version of lemma edition for use with dtsflat
+// Adapted from generateAllData.js
+
+async function generateLemmaTei(timestamp) {
+    const startTime = moment();
+    console.log("started", startTime.format("hh:mm:ss"));
+    const config = loadConfig();
+    const baseURL = `${config.options.repository}/tradition/${config.options.tradition_id}`;
+    const auth = config.auth;
+    const outdir = `public/data/dts-xml_${timestamp}`;
+
+    if (!fs.existsSync("public")) fs.mkdirSync("public", { recursive: true });
+    if (!fs.existsSync("public/data")) fs.mkdirSync("public/data", { recursive: true });
+    if (!fs.existsSync(outdir)) fs.mkdirSync(outdir, { recursive: true });
+
+    // initialize TEI XML
+    let teiDoc = `<?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader xml:id="header">
+        <fileDesc>
+            <titleStmt>
+                <title>The Chronicle of Matthew of Edessa Eclectic Edition</title>
+            </titleStmt>
+            <publicationStmt>
+                <p/>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+    </teiHeader>
+    <text xml:id="lemma">
+        <body xml:lang="hy">`;
+    teiDoc += await fetchAndProcessData().catch((e) => console.log(e));
+    teiDoc += `
+        </body>
+    </text>
+</TEI>`;
+    fs.writeFileSync(`${outdir}/lemma.tei.xml`, teiDoc);
+
+    // load config from json file
+    function loadConfig() {
+        const configJSON = fs.readFileSync(`script/lemma-html-config.json`, "utf8");
+        return JSON.parse(configJSON);
+    }
+
+    // fetch data and append to teiDoc
+    async function fetchAndProcessData() {
+        const sections = await getSections().catch((e) => console.log(e));
+        const sectionsForTei = await Promise.all(
+            sections.map(async (section) => {
+                return getSectionData(section.id);
+            }),
+        );
+        return createTei(sectionsForTei);
+    }
+    async function getSectionData(sectionId) {
+        // get readings for section
+        const allReadings = await getReadings(sectionId);
+        const filteredReadings = allReadings
+            .filter((r) => r.is_lemma && !r.is_start && !r.is_end)
+            .sort((first, second) => first.rank - second.rank);
+        const readings = filteredReadings.map((reading) => {
+            return {
+                text: reading.normal_form ? reading.normal_form : reading.text,
+                id: reading.id,
+                rank: reading.rank,
+                join_next: reading.join_next,
+                join_prior: reading.join_prior,
+            };
+        });
+
+        // get titles for section
+        const titleArray = await getTitle(sectionId);
+        let titles = {};
+        if (Array.isArray(titleArray) && titleArray.length > 0) {
+            const englishTitle = titleArray.find((title) => title.properties.language === "en").properties.text;
+            const armenianTitle = titleArray.find((title) => title.properties.language === "hy").properties.text;
+            // const milestone = armenianTitle.substr(0, 3);
+            titles = {
+                englishTitle: englishTitle,
+                armenianTitle: armenianTitle,
+                // milestone,
+            };
+        } else {
+            console.log("no title for section: ", sectionId);
+        }
+
+        // get annotations for section
+        const commentArray = await getComments(sectionId);
+        const comments = createRefs(commentArray, "comment");
+        const personArray = await getPersons(sectionId);
+        const persons = createRefs(personArray, "person");
+        const placeArray = await getPlaces(sectionId);
+        const places = createRefs(placeArray, "place");
+        const dateArray = await getDates(sectionId);
+        const dates = createRefs(dateArray, "date");
+
+        // create section object
+        return {
+            id: sectionId,
+            titles,
+            readings,
+            annotations: [...comments, ...persons, ...places, ...dates],
+        };
+    }
+
+    // helper to strip html tags from text
+    function stripTags(original) {
+        return original.replace(/(<([^>]+)>)/gi, "");
+    }
+
+    async function getSections() {
+        const response = await axios.get(`${baseURL}/sections`, { auth }).catch((e) => console.log(e));
+        return response.data;
+    }
+    async function getReadings(sectionId) {
+        const sectionURL = `${baseURL}/section/${sectionId}`;
+        const response = await axios.get(`${sectionURL}/readings`, { auth }).catch((e) => console.log(e));
+        return response.data;
+    }
+
+    async function getTitle(sectionId) {
+        const sectionURL = `${baseURL}/section/${sectionId}`;
+        const response = await axios
+            .get(`${sectionURL}/annotations`, {
+                auth,
+                params: { label: "TITLE" },
+            })
+            .catch((e) => console.log(e));
+        return response.data;
+    }
+    async function getPersons(sectionId) {
+        const annotationURL = `${baseURL}/section/${sectionId}/annotations`;
+        try {
+            const response = await axios
+                .get(`${annotationURL}`, {
+                    auth,
+                    params: { label: "PERSONREF" },
+                })
+                .catch((e) => console.log(e));
+            return response.data;
+        } catch (error) {
+            console.log(`no person refs for section ${sectionId} `);
+            return null;
+        }
+    }
+
+    async function getComments(sectionId) {
+        const annotationURL = `${baseURL}/section/${sectionId}/annotations`;
+        try {
+            const response = await axios
+                .get(`${annotationURL}`, { auth, params: { label: "COMMENT" } })
+                .catch((e) => console.log(e));
+            return response.data;
+        } catch (error) {
+            console.log(`no comments for section ${sectionId} `);
+            return null;
+        }
+    }
+
+    async function getPlaces(sectionId) {
+        const annotationURL = `${baseURL}/section/${sectionId}/annotations`;
+        try {
+            const response = await axios
+                .get(`${annotationURL}`, {
+                    auth,
+                    params: { label: "PLACEREF" },
+                })
+                .catch((e) => console.log(e));
+            return response.data;
+        } catch (error) {
+            console.log(`no place refs for section ${sectionId} `);
+            return null;
+        }
+    }
+
+    async function getDates(sectionId) {
+        const annotationURL = `${baseURL}/section/${sectionId}/annotations`;
+        const response = await axios
+            .get(`${annotationURL}`, { auth, params: { label: "DATEREF" } })
+            .catch((e) => console.log(e));
+        return response.data;
+    }
+
+    function createRefs(annotations, type) {
+        // Given an annotation and its type, return an object with its properties, and the ids of
+        // the beginning and ending nodes that it annotates
+        return annotations.map((anno) => {
+            const beginNodeId = anno.links.find((l) => l.type == "BEGIN").target;
+            const endNodeId = anno.links.find((l) => l.type == "END").target;
+            let ref = {
+                id: anno.id,
+                begin: beginNodeId,
+                end: endNodeId,
+                type,
+            };
+            if (anno.properties && anno.properties.text) {
+                ref["text"] = stripTags(anno.properties.text);
+            }
+            return ref;
+        });
+    }
+
+    function getOpenTag(annotation) {
+        // Get the opening TEI tag depending on the type of annotation
+        switch (annotation.type) {
+            case "comment":
+                return `<ref target="annotation_${annotation.id}">`;
+            case "person":
+                return `<name ref="person_${annotation.id}">`;
+            case "place":
+                return `<name ref="place_${annotation.id}">`;
+            case "date":
+                return "<date>";
+        }
+    }
+
+    function getCloseTag(annotation) {
+        // Get the closing TEI tag depending on the type of annotation
+        switch (annotation.type) {
+            case "comment":
+                return `</ref><note xml:id="annotation_${annotation.id}" xml:lang="en">${annotation.text}</note>`;
+            case "person":
+            case "place":
+                return `</name>`;
+            case "date":
+                return "</date>";
+        }
+    }
+
+    function makeLists(nodeList) {
+        // Collect all the persons and places from nodes into lists
+        const placeList = [];
+        const personList = [];
+        nodeList.forEach((node) => {
+            if (node.annotations) {
+                node.annotations.forEach((anno) => {
+                    // add places/persons to lists if not present yet
+                    if (anno.type === "place" && !placeList.some((place) => place.id === anno.id)) {
+                        placeList.push(anno);
+                    } else if (anno.type === "person" && !personList.some((person) => person.id === anno.id)) {
+                        personList.push(anno);
+                    }
+                });
+            }
+        })
+        // Create listPerson and listPlace TEI elements with contents from annotations
+        let lists = "";
+        const indent = " ".repeat(16);
+        const indent2 = " ".repeat(20);
+        if (personList.length > 0) {
+            lists += `${indent}<listPerson>\n`;
+            personList.forEach((person) => {
+                lists += `${indent2}<person xml:id="person_${person.id}"><persName xml:lang="hy">${person.text}</persName></person>\n`;
+            });
+            lists += `${indent}</listPerson>${placeList.length > 0 ? "\n" : ""}`;
+        }
+        if (placeList.length > 0) {
+            lists += `${indent}<listPlace>\n`;
+            placeList.forEach((place) => {
+                lists += `${indent2}<place xml:id="place_${place.id}"><placeName xml:lang="hy">${place.text}</placeName></place>\n`;
+            });
+            lists += `${indent}</listPlace>`;
+        }
+        return lists;
+    }
+
+    function createNodeTei(node) {
+        const space = node.needsSpaceBefore ? " " : "";
+        let text = stripTags(node.text);
+        if (node.annotations) {
+            node.annotations.forEach((anno) => {
+                if (anno.isStart && anno.isEnd) {
+                    // if this is the start and end of an annotation, wrap with tags
+                    // check for existing tags to make sure we don't break them
+                    const existingCloseTag = text.indexOf("</");
+                    if (existingCloseTag > -1) {
+                        const before = text.substring(0, existingCloseTag);
+                        const after = text.substring(existingCloseTag);
+                        text = `${getOpenTag(anno)}${before}${getCloseTag(anno)}${after}`;
+                    } else {
+                        text = `${getOpenTag(anno)}${text}${getCloseTag(anno)}`;
+                    }
+                    // NOTE: Are there other conditions where we would need to do this?
+                } else if (anno.isStart) {
+                    // if this is the start of an annotation, add open tag
+                    text = `${getOpenTag(anno)}${text}`;
+                } else if (anno.isEnd) {
+                    // if this is the end of an annotation, add close tag
+                    text = `${text}${getCloseTag(anno)}`;
+                }
+            });
+        }
+        return `${space}${text}`;
+    }
+
+    function createSectionTei(annotations, sectionNodes) {
+        // add annotations markup to lemma text
+        let annotatedNodes = [];
+        // add annotation data to start, end, and middle nodes for each annotation
+        annotations.forEach((anno) => {
+            const startNode = sectionNodes.find((node) => parseInt(node.id) === parseInt(anno.begin));
+            let nodesBetween = [];
+            const endNode = sectionNodes.find((node) => parseInt(node.id) === parseInt(anno.end));
+            if (startNode && endNode) {
+                if (startNode.id === endNode.id) {
+                    // annotation is only on this one node
+                    const nodeAnnotation = {
+                        ...anno,
+                        isStart: true,
+                        isEnd: true,
+                        // Use node text for annotation text unless annotation has text already
+                        text: anno.text ? anno.text : startNode.text,
+                    };
+                    if (startNode.annotations) startNode.annotations.push(nodeAnnotation);
+                    else startNode.annotations = [nodeAnnotation];
+                } else {
+                    // annotation spans multiple nodes
+                    // build annotation text
+                    let annoText = "";
+                    let filteredNodes = [];
+                    annoText += startNode.text;
+                    // if there are nodes between the start and end nodes, get text from them
+                    const nodesAreBetween = ![endNode.startPos, endNode.startPos - 1].includes(startNode.endPos);
+                    if (nodesAreBetween) {
+                        const filteredNodes = sectionNodes.filter(
+                            (node) => node.startPos >= startNode.endPos && node.endPos <= endNode.startPos,
+                        );
+                        filteredNodes.forEach((node) => {
+                            annoText += (node.needsSpaceBefore ? " " : "") + node.text;
+                        });
+                    }
+                    annoText += (endNode.needsSpaceBefore ? " " : "") + endNode.text;
+                    const newAnno = { ...anno, text: anno.text ? anno.text : annoText };
+                    // append annotation to start, between, and end nodes
+                    const anStart = { ...newAnno, isStart: true, isEnd: false };
+                    if (startNode.annotations) startNode.annotations.push(anStart);
+                    else startNode.annotations = [anStart];
+                    if (nodesAreBetween) {
+                        nodesBetween = filteredNodes.map((node) => {
+                            const nodeAnno = {
+                                ...newAnno,
+                                isStart: false,
+                                isEnd: false,
+                            };
+                            if (node.annotations) node.annotations.push(nodeAnno);
+                            else node.annotations = [nodeAnno];
+                            return node;
+                        });
+                    }
+                    const anEnd = { ...newAnno, isEnd: true, isStart: false };
+                    if (endNode.annotations) endNode.annotations.push(anEnd);
+                    else endNode.annotations = [anEnd];
+                }
+                // store all annotated nodes
+                annotatedNodes.push(startNode, ...nodesBetween, endNode);
+            }
+        });
+        // replace section nodes with annotated ones when possible
+        const allNodes = sectionNodes.map((node) => {
+            const annoNode = annotatedNodes.find((n) => n.id === node.id);
+            return annoNode || node;
+        });
+        // collect the markup for each node and generate TEI
+        const paragraph = allNodes.map((node) => createNodeTei(node)).join("");
+        // create the metadata lists
+        const lists = makeLists(allNodes);
+        return paragraph ? `<p>${paragraph}</p>\n${lists}` : "";
+    }
+
+    // compose a TEI div for each section
+    function createTei(sections) {
+        const sectionsTei = sections.map((section) => {
+            let sectionNodes = [];
+            let pos = 0;
+            section.readings.forEach((reading, i) => {
+                sectionNodes.push({
+                    id: reading.id,
+                    text: reading.text,
+                    needsSpaceBefore: i > 0 && !reading.join_prior && !section.readings[i - 1].join_next,
+                    startPos: pos,
+                    endPos: pos + reading.text.length,
+                });
+                pos += reading.text.length;
+            });
+            const markedupText = createSectionTei(section.annotations, sectionNodes);
+            const head1 = section.titles?.armenianTitle
+                ? `                <head xml:lang="hy">${section.titles.armenianTitle}</head>\n`
+                : "";
+            const head2 = section.titles?.englishTitle
+                ? `                <head xml:lang="en">${section.titles.englishTitle}</head>`
+                : "";
+            return `
+            <div xml:id="section_${section.id}">${head1 || head2 ? "\n" : ""}${head1}${head2}
+                ${markedupText}
+            </div>`;
+        });
+        return sectionsTei.join("");
+    }
+}
+
+const timestamp = process.argv[2];
+generateLemmaTei(timestamp);

--- a/script/generateLemmaTei.js
+++ b/script/generateLemmaTei.js
@@ -13,6 +13,7 @@ async function generateLemmaTei(timestamp) {
     const auth = config.auth;
     const outdir = `public/data/dts-xml_${timestamp}`;
 
+    // initialize directory structure
     if (!fs.existsSync("public")) fs.mkdirSync("public", { recursive: true });
     if (!fs.existsSync("public/data")) fs.mkdirSync("public/data", { recursive: true });
     if (!fs.existsSync(outdir)) fs.mkdirSync(outdir, { recursive: true });
@@ -272,6 +273,7 @@ async function generateLemmaTei(timestamp) {
     }
 
     function createNodeTei(node) {
+        // create TEI markup for a single node
         const space = node.needsSpaceBefore ? " " : "";
         let text = stripTags(node.text);
         if (node.annotations) {
@@ -379,6 +381,7 @@ async function generateLemmaTei(timestamp) {
         const sectionsTei = sections.map((section) => {
             let sectionNodes = [];
             let pos = 0;
+            // add each section (with start and end positions in the text) to sectionNodes
             section.readings.forEach((reading, i) => {
                 sectionNodes.push({
                     id: reading.id,
@@ -389,6 +392,7 @@ async function generateLemmaTei(timestamp) {
                 });
                 pos += reading.text.length;
             });
+            // create markup and return the TEI div
             const markedupText = createSectionTei(section.annotations, sectionNodes);
             const head1 = section.titles?.armenianTitle
                 ? `                <head xml:lang="hy">${section.titles.armenianTitle}</head>\n`


### PR DESCRIPTION
## In this PR

- Change `UTF8` to `utf-8` in all manuscript TEI (needed for `simple-tei2dtsflat`)
- Scripts for generating a DTSFlat file structure out of the lemma and manuscript texts (`generateDtsData.js`), and instructions for serving it with Nginx

## Questions

- Does it make sense to have `generateDtsData.js` as a separate script from `generateAllData.js`, or should it all be part of `generateAllData.js` since we want to run both every time the lemma is updated?
- In `generateLemmaTei.js`, there's a section I'm not sure about that I would especially love feedback on. It has to do with dealing with opening and closing tags: (I'm not even sure the overall approach of `createSectionTei`/`createNodeTei` is robust, so would greatly appreciate any and all feedback)
   https://github.com/performant-software/chronicleME/blob/b2bbe3ea92da3d5c2a9486b44b034fff82eb6a0a/script/generateLemmaTei.js#L284-L292
- My nginx skill isn't terribly strong, so I'm not sure if there's a better way to do this—for example, would it be possible to just serve the DTS endpoints from `http://hostname/dts/` instead of `http://hostname:3333/dts/` when there's already another service running on `:80`? I think this would be better but since they both seem to need a `root` directive, I'm not sure how to do it. The full config is on the server at `/etc/nginx/sites-available/default`.