### PR TITLE
Cleanup: Fix linter/console errors/warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,10 +2,12 @@
     "parser": "babel-eslint",
     "env": {
         "browser": true,
-        "node": true
+        "node": true,
+        "es6": true
     },
     "rules": {
         "eol-last": [0],
+        "no-undef": "error",
         "strict": 0,
         "react/display-name": 0,
         "react/jsx-boolean-value": 1,

--- a/README.md
+++ b/README.md
@@ -2,34 +2,43 @@ This is an experimental interface for viewing variant text. Development was begu
 
 This fork has updated the original proof of concept to use live data, and reworked it to be supported by the [Create React App](https://github.com/facebook/create-react-app) infrastructure.
 
+## Requirements
+
+-   Node.JS 14+, npm 7+
+-   Python 3
+-   [Graphviz](https://graphviz.org/)
+
 ## Setup
 
 ### Install Dependencies
 
-Within the root directory, install dependencies required to run the application:  
-```
+Within the root directory, install dependencies required to run the application:
+
+```sh
 npm install
 ```
 
 ### Environment Variables
+
 1. Within the root directory, create a new file named `.env`. **It is highly recommended that this file be git-ignored in order to avoid committing sensitive data into version control.**
 
 2. In the newly created `.env` file, add the following environment variables:
-* **`PUBLIC_URL`**
-  * Ex: `PUBLIC_URL=enter_url_here_with_no_spaces_or_quotes`
-* **`REACT_APP_MAPBOX_TOKEN`**
-  * Ex: `REACT_APP_MAPBOX_TOKEN=enter_token_here_with_no_spaces_or_quotes`
-  * A Mapbox token can be obtained from the [Mapbox website](www.mapbox.com) - see the "Access tokens" section of your Mapbox account page.
-* **`REACT_APP_HOMEPATH`**
-  * Ex: `REACT_APP_HOMEPATH=/ChronicleME/`
 
+-   **`PUBLIC_URL`**
+    -   Ex: `PUBLIC_URL=enter_url_here_with_no_spaces_or_quotes`
+-   **`REACT_APP_MAPBOX_TOKEN`**
+    -   Ex: `REACT_APP_MAPBOX_TOKEN=enter_token_here_with_no_spaces_or_quotes`
+    -   A Mapbox token can be obtained from the [Mapbox website](www.mapbox.com) - see the "Access tokens" section of your Mapbox account page.
+-   **`REACT_APP_HOMEPATH`**
+    -   Ex: `REACT_APP_HOMEPATH=/ChronicleME/`
 
 ### API Configuration
-1. Within the `/script` directory, create a new file named `lemma-html-config.json`.  **It is highly recommended that this file be git-ignored in order to avoid committing sensitive data into version control** - this is why we provide an example file (`lemma-html-config.json.example`), rather than the file itself, on GitHub.
+
+1. Within the `/script` directory, create a new file named `lemma-html-config.json`. **It is highly recommended that this file be git-ignored in order to avoid committing sensitive data into version control** - this is why we provide an example file (`lemma-html-config.json.example`), rather than the file itself, on GitHub.
 
 2. In the newly created `lemma-html-config.json` file, add a JSON object with the following keys (be sure to update with your own values):
 
-```
+```json
 {
     "options": {
         "repository": "repository URL goes inside these quotes",
@@ -44,31 +53,36 @@ npm install
 
 **Note** - an example file, `lemma-html-config.json.example`, has been provided as an example.
 
-
 ### Data Generation
 
 Within the root directory, run the following command:
 
-```
+```sh
 node script/generateAllData.js
 ```
 
 ## Local Development
+
 Run the application locally:
 
-```
-yarn start
+```sh
+npm run start
 ```
 
 ## Deploying
+
 **Within the project root directory:**
+
 ```
-yarn build   
+npm run build
 zip -r <buildID> build
-scp <buildID>.zip edition@monitor.stemmaweb.net:.
+scp <buildID>.zip <user>:<pass>@<hostname>:<path>
 ```
 
-**On the server:**  
+For Stemmaweb, the final argument should be something like `edition@monitor.stemmaweb.net:.`.
+
+**On the server:**
+
 ```rm -rf build
 unzip <buildID>
 rm -rf www/*

--- a/script/generateAllWitnessLunrData.js
+++ b/script/generateAllWitnessLunrData.js
@@ -58,12 +58,10 @@ async function generateLunrSource(timestamp) {
         const sectionPromises = [];
         const validSections = [];
         sections.forEach((section) => {
-            sectionData = getSectionData(section.id, witnesses);
+            let sectionData = getSectionData(section.id, witnesses);
             sectionPromises.push(sectionData);
         });
-        sectionStore = await Promise.all(sectionPromises).catch((e) =>
-            console.log(e)
-        );
+        await Promise.all(sectionPromises).catch((e) => console.log(e));
         writeTranslationDataIndexFiles();
         writeArmenianDataIndexFiles();
     }
@@ -97,9 +95,9 @@ async function generateLunrSource(timestamp) {
                 });
             });
 
-            return (data = await Promise.all([allReadings]).catch((e) =>
+            return await Promise.all([allReadings]).catch((e) =>
                 console.log(e)
-            ));
+            );
         }
     }
 

--- a/script/generateDates.js
+++ b/script/generateDates.js
@@ -145,7 +145,7 @@ async function generateDates(timestamp) {
                 .catch((e) => console.log(e));
             return response.data;
         } catch (error) {
-            console.log(`no place refs for section ${sectionId} `);
+            console.log("error fetching all date annotations", error);
             return null;
         }
     }
@@ -160,7 +160,7 @@ async function generateDates(timestamp) {
                 .catch((e) => console.log(e));
             return response.data;
         } catch (error) {
-            console.log(`no place refs for section ${sectionId} `);
+            console.log("error fetching all date refs", error);
             return null;
         }
     }
@@ -175,7 +175,7 @@ async function generateDates(timestamp) {
                 .catch((e) => console.log(e));
             return response.data;
         } catch (error) {
-            console.log(`no place refs for section ${sectionId} `);
+            console.log("error fetching all datings", error);
             return null;
         }
     }

--- a/script/generateLocationData.js
+++ b/script/generateLocationData.js
@@ -58,7 +58,7 @@ async function GenerateLocationData(timestamp) {
     }
 
     async function fetchKMLLocation(url, originalUrl, place) {
-        return (geoData = await Promise.resolve(getGeoJson(url))
+        return await Promise.resolve(getGeoJson(url))
             .catch((e) => console.log(e))
             .then((openData) => {
                 const record = openData.data;
@@ -85,11 +85,11 @@ async function GenerateLocationData(timestamp) {
             })
             .catch((error) => {
                 console.log(error);
-            }));
+            });
     }
 
     async function fetchSyriacLocation(url, place) {
-        return (geoData = await Promise.resolve(getGeoJson(url))
+        return await Promise.resolve(getGeoJson(url))
             .catch((e) => console.log(e))
             .then((openData) => {
                 const $ = cheerio.load(openData.data.trim());
@@ -119,11 +119,11 @@ async function GenerateLocationData(timestamp) {
                     });
                 }
             })
-            .catch((error) => console.log(error)));
+            .catch((error) => console.log(error));
     }
 
     async function fetchGeoJsonLocation(url, place) {
-        return (geoData = await Promise.resolve(getGeoJson(url))
+        return await Promise.resolve(getGeoJson(url))
             .catch((e) => console.log(e))
             .then((openData) => {
                 const record = openData.data;
@@ -137,7 +137,7 @@ async function GenerateLocationData(timestamp) {
                     links: place.links,
                 });
             })
-            .catch((error) => console.log(error)));
+            .catch((error) => console.log(error));
     }
 
     function writeLocationFile() {
@@ -160,7 +160,7 @@ async function GenerateLocationData(timestamp) {
     }
 
     async function getGeoJson(url) {
-        return (response = await axios.get(url).catch((e) => console.log(e)));
+        return await axios.get(url).catch((e) => console.log(e));
     }
 
     async function makeDirectory() {

--- a/script/generateLunrData.js
+++ b/script/generateLunrData.js
@@ -59,12 +59,10 @@ async function generateLunrSource(timestamp) {
         const sectionPromises = [];
         const validSections = [];
         sections.forEach((section) => {
-            sectionData = getSectionData(section.id);
+            let sectionData = getSectionData(section.id);
             sectionPromises.push(sectionData);
         });
-        sectionStore = await Promise.all(sectionPromises).catch((e) =>
-            console.log(e)
-        );
+        await Promise.all(sectionPromises).catch((e) => console.log(e));
         writeTranslationDataIndexFiles();
         writeLemmaDataIndexFiles();
     }
@@ -90,9 +88,9 @@ async function generateLunrSource(timestamp) {
                 });
             });
 
-            return (data = await Promise.all([allReadings]).catch((e) =>
+            return await Promise.all([allReadings]).catch((e) =>
                 console.log(e)
-            ));
+            );
         }
     }
 

--- a/script/generateStore.js
+++ b/script/generateStore.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
 const axios = require("axios");
 const moment = require("moment");
-//const CETEI = require('./../utils/CETEI')
 const lunr = require("lunr");
 const timestamp = process.argv[2];
 //https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await
@@ -61,12 +60,11 @@ async function generateStore(timestamp) {
         const validSections = [];
         sections.forEach((section) => {
             console.log("fetching manuscripts with section", section.id);
-            sectionData = getSectionData(section.id, witnesses, validSections);
-            sectionPromises.push(sectionData);
+            sectionPromises.push(
+                getSectionData(section.id, witnesses, validSections)
+            );
         });
-        sectionStore = await Promise.all(sectionPromises).catch((e) =>
-            console.log(e)
-        );
+        await Promise.all(sectionPromises).catch((e) => console.log(e));
         validSections.sort((a, b) => {
             a.milestone - b.milestone;
         });
@@ -148,13 +146,13 @@ async function generateStore(timestamp) {
                 resolve();
             });
         });
-        return (data = await Promise.all([
+        return await Promise.all([
             allReadings,
             titleArray,
             personArray,
             commentArray,
             placeArray,
-        ]).catch((e) => console.log(e)));
+        ]).catch((e) => console.log(e));
     }
 
     async function getLemmaText(sectionId) {
@@ -254,24 +252,6 @@ async function generateStore(timestamp) {
             .get(`${annotationURL}`, { auth, params: { label: "DATEREF" } })
             .catch((e) => console.log(e));
         return response.data;
-    }
-
-    async function getManuscript(manuscriptId) {
-        const manuscriptDir = `images/mss/${manuscriptId}`;
-        const manuscriptFile = `${manuscriptDir}/${manuscriptId}.html`;
-        const manuscriptURL = `${manuscriptDir}/${manuscriptId}.tei.xml`;
-        const response = await axios
-            .get(`${manuscriptURL}`)
-            .catch((e) => console.log(e));
-        var TEI = response;
-        const CETEIcean = new CETEI();
-        let htmlContainer;
-        CETEIcean.makeHTML5(TEI, function (data) {
-            htmlContainer = document.createElement("div");
-            htmlContainer.appendChild(data);
-        });
-
-        writeFile(manuscriptFile, htmlContainer.innerHTML);
     }
 
     function readingToHTML(reading) {

--- a/script/generate_svgs.py
+++ b/script/generate_svgs.py
@@ -48,10 +48,17 @@ def collect_section_data(options, section, outdir, auth=None):
         'show_normal': 'true',
         'normalise': 'spelling'
     }
-    r = requests.get("%s/dot" % baseurl, params=dotparams, auth=auth)
+    try:
+        r = requests.get("%s/dot" % baseurl, params=dotparams, auth=auth)
+    except Exception:
+        print("error with request: %s/dot" % baseurl)
     r.raise_for_status()
     dot = r.text
-    dotresult = subprocess.run(["dot", "-Tsvg"], input=r.text, stdout=subprocess.PIPE, encoding='utf-8')
+    try:
+        dotresult = subprocess.run(["dot", "-Tsvg"], input=r.text, check=True, stdout=subprocess.PIPE, encoding='utf-8')
+    except subprocess.CalledProcessError as e:
+        print(e)
+
     dotresult.check_returncode()
     with open('%s/graph.svg' % sectiondir, 'w', encoding='utf-8') as svg:
         svg.write(dotresult.stdout)
@@ -103,4 +110,4 @@ if __name__ == '__main__':
 
     # Go do the work.
     collect_tradition_data(args, auth=authobj)
-    print("Done!")
+    print("Done generating SVGs")

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -1,9 +1,8 @@
 import React, { Fragment } from "react";
+import PropTypes from "prop-types";
 import Header from "./Header";
 
-const AboutPage = (props) => {
-    const { onSearch } = props;
-
+const AboutPage = ({ onSearch }) => {
     return (
         <Fragment>
             <Header onSearch={onSearch} />
@@ -346,4 +345,9 @@ const AboutPage = (props) => {
         </Fragment>
     );
 };
+
+AboutPage.propTypes = {
+    onSearch: PropTypes.func,
+};
+
 export default AboutPage;

--- a/src/components/Edition/Citation.js
+++ b/src/components/Edition/Citation.js
@@ -1,8 +1,7 @@
 import React from "react";
+import PropTypes from "prop-types";
 
-const Citation = (props) => {
-    const { selectedTimestamp } = props;
-
+const Citation = ({ selectedTimestamp }) => {
     const citationDate = selectedTimestamp
         ? new Date(selectedTimestamp.split("_").slice(1)).toLocaleString(
               "default",
@@ -27,6 +26,10 @@ const Citation = (props) => {
             </p>
         </div>
     );
+};
+
+Citation.propTypes = {
+    selectedTimestamp: PropTypes.string,
 };
 
 export default Citation;

--- a/src/components/Edition/EditionHeader.js
+++ b/src/components/Edition/EditionHeader.js
@@ -1,11 +1,10 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Typography from "@material-ui/core/Typography";
 import { Grid } from "@material-ui/core";
 import Navigation from "./../Navigation";
 
-const EditionHeader = (props) => {
-    const { onSearch } = props;
-
+const EditionHeader = ({ onSearch }) => {
     return (
         <Grid container spacing={0} style={{ maxHeight: "112px" }}>
             <Grid item xs={12} className="header">
@@ -32,5 +31,8 @@ const EditionHeader = (props) => {
             </Grid>
         </Grid>
     );
+};
+EditionHeader.propTypes = {
+    onSearch: PropTypes.func,
 };
 export default EditionHeader;

--- a/src/components/Edition/PreviousNext.js
+++ b/src/components/Edition/PreviousNext.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
 import PlayCircleOutlineOutlinedIcon from "@material-ui/icons/PlayCircleOutlineOutlined";
 import IconButton from "@material-ui/core/IconButton";
 import Typography from "@material-ui/core/Typography";
@@ -10,9 +11,7 @@ const buttonStyles = {
     },
 };
 
-const PreviousNext = (props) => {
-    const { onPrevious, onNext, sections, sectionId } = props;
-
+const PreviousNext = ({ onPrevious, onNext, sections, sectionId }) => {
     const [title, setTitle] = useState();
 
     useEffect(() => {
@@ -69,6 +68,13 @@ const PreviousNext = (props) => {
             </IconButton>
         </div>
     );
+};
+
+PreviousNext.propTypes = {
+    onNext: PropTypes.func,
+    onPrevious: PropTypes.func,
+    sectionId: PropTypes.string,
+    sections: PropTypes.array,
 };
 
 export default withStyles(buttonStyles)(PreviousNext);

--- a/src/components/Edition/RankDisonance.js
+++ b/src/components/Edition/RankDisonance.js
@@ -88,11 +88,8 @@ const RankDisonance = ({
                         }
                         scale={{ x: "linear", y: "linear" }}
                     >
-                        <VictoryAxis crossAxis style={xaxisStyle}></VictoryAxis>
-                        <VictoryAxis
-                            dependentAxis
-                            style={yaxisStyle}
-                        ></VictoryAxis>
+                        <VictoryAxis crossAxis style={xaxisStyle} />
+                        <VictoryAxis dependentAxis style={yaxisStyle} />
                         <VictoryBar
                             style={{
                                 data: {
@@ -201,7 +198,7 @@ const RankDisonance = ({
                                     }, // end event handlers
                                 },
                             ]}
-                        ></VictoryBar>
+                        />
                     </VictoryChart>
                 </div>
             )}

--- a/src/components/Edition/RankDisonance.js
+++ b/src/components/Edition/RankDisonance.js
@@ -155,15 +155,11 @@ const RankDisonance = ({
                                                                 parseInt(key);
                                                             const rangeStart =
                                                                 selectedSentence
-                                                                    ? parseInt(
-                                                                          selectedSentence.startRank
-                                                                      )
+                                                                    ? selectedSentence.startRank
                                                                     : null;
                                                             const rangeEnd =
                                                                 selectedSentence
-                                                                    ? parseInt(
-                                                                          selectedSentence.endRank
-                                                                      )
+                                                                    ? selectedSentence.endRank
                                                                     : null;
 
                                                             if (

--- a/src/components/Edition/RankDisonance.js
+++ b/src/components/Edition/RankDisonance.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import * as DataApi from "../../utils/Api";
 import {
     VictoryChart,
@@ -7,16 +8,15 @@ import {
     VictoryAxis,
 } from "victory";
 
-const RankDisonance = (props) => {
-    const {
-        sectionId,
-        highlightedNode,
-        selectedRank,
-        selectedSentence,
-        onSelectRank,
-        viewport,
-        selectedTimestamp,
-    } = props;
+const RankDisonance = ({
+    sectionId,
+    highlightedNode,
+    selectedRank,
+    selectedSentence,
+    onSelectRank,
+    viewport,
+    selectedTimestamp,
+}) => {
     const [chartData, setChartData] = useState();
 
     useEffect(() => {
@@ -245,5 +245,24 @@ const RankDisonance = (props) => {
         });
         return data;
     }
+};
+RankDisonance.propTypes = {
+    highlightedNode: PropTypes.shape({
+        nodeId: PropTypes.string,
+        rank: PropTypes.number,
+    }),
+    onSelectRank: PropTypes.func,
+    sectionId: PropTypes.string,
+    selectedRank: PropTypes.number,
+    selectedSentence: PropTypes.shape({
+        startId: PropTypes.string,
+        startRank: PropTypes.number,
+        endRank: PropTypes.number,
+    }),
+    selectedTimestamp: PropTypes.string,
+    viewport: PropTypes.shape({
+        width: PropTypes.number,
+        height: PropTypes.number,
+    }),
 };
 export default RankDisonance;

--- a/src/components/Edition/SearchResults.js
+++ b/src/components/Edition/SearchResults.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import EditionHeader from "./EditionHeader";
 import Paper from "@material-ui/core/Paper";
@@ -12,16 +13,15 @@ import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
-const SearchResults = (props) => {
-    const {
-        searchTerm,
-        onSearch,
-        translationDictionary,
-        translationIndex,
-        armenianDictionary,
-        armenianIndex,
-        sections,
-    } = props;
+const SearchResults = ({
+    searchTerm,
+    onSearch,
+    translationDictionary,
+    translationIndex,
+    armenianDictionary,
+    armenianIndex,
+    sections,
+}) => {
     const [groupedResults, setGroupedResults] = useState([]);
     const [dataDictionary, setDataDictionary] = useState([]);
     const [isArmenian, setIsArmenian] = useState();
@@ -319,6 +319,16 @@ const SearchResults = (props) => {
 
         setGroupedResults(groupedYears);
     }
+};
+
+SearchResults.propTypes = {
+    armenianDictionary: PropTypes.array,
+    armenianIndex: PropTypes.object,
+    onSearch: PropTypes.func,
+    searchTerm: PropTypes.string,
+    sections: PropTypes.array,
+    translationDictionary: PropTypes.array,
+    translationIndex: PropTypes.object,
 };
 
 export default SearchResults;

--- a/src/components/Edition/SearchResults.js
+++ b/src/components/Edition/SearchResults.js
@@ -8,9 +8,9 @@ import Typography from "@material-ui/core/Typography";
 import Parser, { domToReact } from "html-react-parser";
 import { Link } from "react-router-dom";
 import Button from "@material-ui/core/Button";
-import ExpansionPanel from "@material-ui/core/ExpansionPanel";
-import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
-import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import Accordion from "@material-ui/core/Accordion";
+import AccordionSummary from "@material-ui/core/AccordionSummary";
+import AccordionDetails from "@material-ui/core/AccordionDetails";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
 const SearchResults = ({
@@ -145,8 +145,8 @@ const SearchResults = ({
                                                 key={r.year}
                                                 style={{ marginBottom: "16px" }}
                                             >
-                                                <ExpansionPanel>
-                                                    <ExpansionPanelSummary
+                                                <Accordion>
+                                                    <AccordionSummary
                                                         expandIcon={
                                                             <ExpandMoreIcon />
                                                         }
@@ -160,8 +160,8 @@ const SearchResults = ({
                                                                 ? `Witness`
                                                                 : `Witnesses`}
                                                         </Typography>
-                                                    </ExpansionPanelSummary>
-                                                    <ExpansionPanelDetails
+                                                    </AccordionSummary>
+                                                    <AccordionDetails
                                                         style={{
                                                             display: "flex",
                                                             flexDirection:
@@ -201,8 +201,8 @@ const SearchResults = ({
                                                                 );
                                                             }
                                                         )}
-                                                    </ExpansionPanelDetails>
-                                                </ExpansionPanel>
+                                                    </AccordionDetails>
+                                                </Accordion>
                                             </div>
                                         );
                                     })

--- a/src/components/Edition/SectionList.js
+++ b/src/components/Edition/SectionList.js
@@ -89,7 +89,7 @@ const SectionList = ({ list, sectionId, height, witnessId }) => {
     );
 };
 SectionList.propTypes = {
-    height: PropTypes.number,
+    height: PropTypes.string,
     list: PropTypes.array,
     sectionId: PropTypes.string,
     witnessId: PropTypes.string,

--- a/src/components/Edition/SectionList.js
+++ b/src/components/Edition/SectionList.js
@@ -1,13 +1,12 @@
 import React from "react";
+import PropTypes from "prop-types";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import Typography from "@material-ui/core/Typography";
 import Paper from "@material-ui/core/Paper";
 import { Link } from "react-router-dom";
 
-const SectionList = (props) => {
-    const { list, sectionId, height, witnessId } = props;
-
+const SectionList = ({ list, sectionId, height, witnessId }) => {
     const titleDisplay = (title) => {
         const wordArray = title.split(" ");
         const firstThreeWords = wordArray.slice(0, 3).join(" ");
@@ -21,7 +20,7 @@ const SectionList = (props) => {
     return (
         <Paper
             elevation={2}
-            style={{ marginLeft: "16px", height: height, overflowY: "auto" }}
+            style={{ marginLeft: "16px", height, overflowY: "auto" }}
         >
             <Typography variant="h6" style={{ margin: "16px 24px 0px" }}>
                 {"Index"}
@@ -88,5 +87,11 @@ const SectionList = (props) => {
             </div>
         </Paper>
     );
+};
+SectionList.propTypes = {
+    height: PropTypes.number,
+    list: PropTypes.array,
+    sectionId: PropTypes.string,
+    witnessId: PropTypes.string,
 };
 export default SectionList;

--- a/src/components/Edition/SvgGraph.js
+++ b/src/components/Edition/SvgGraph.js
@@ -1,22 +1,21 @@
 import React, { useEffect, useRef } from "react";
+import PropTypes from "prop-types";
 import SVG from "react-inlinesvg";
 import panzoom from "panzoom";
 
-const SvgGraph = (props) => {
-    const {
-        sectionId,
-        highlightedNode,
-        selectedSentence,
-        selectedRank,
-        onSelectNode,
-        nodeHash,
-        nodeList,
-        persons,
-        places,
-        dates,
-        selectedTimestamp,
-    } = props;
-
+const SvgGraph = ({
+    sectionId,
+    highlightedNode,
+    selectedSentence,
+    selectedRank,
+    onSelectNode,
+    nodeHash,
+    nodeList,
+    persons,
+    places,
+    dates,
+    selectedTimestamp,
+}) => {
     const svgRef = useRef(null);
 
     useEffect(() => {
@@ -28,9 +27,9 @@ const SvgGraph = (props) => {
     }, [persons, places, dates]);
 
     useEffect(() => {
-        if (props.selectedRank) {
+        if (selectedRank) {
             let nodesAtRank = nodeList.filter(
-                (n) => n.rank === parseInt(props.selectedRank)
+                (n) => n.rank === parseInt(selectedRank)
             );
             for (let i = 0; i < nodesAtRank.length; i++) {
                 const zoomNode = getGraphDOMNode(nodesAtRank[i].id);
@@ -41,21 +40,21 @@ const SvgGraph = (props) => {
             }
         }
         highlightAndSelect();
-    }, [props.selectedRank, nodeList]);
+    }, [selectedRank, nodeList]);
 
     useEffect(() => {
-        if (props.selectedSentence) {
-            const domNode = getGraphDOMNode(props.selectedSentence.startId);
+        if (selectedSentence) {
+            const domNode = getGraphDOMNode(selectedSentence.startId);
             zoomToNode(domNode);
         }
         highlightAndSelect();
-    }, [props.selectedSentence]);
+    }, [selectedSentence]);
 
     useEffect(() => {
-        if (!props.highlightedNode) return;
-        const domNode = getGraphDOMNode(props.highlightedNode.nodeId);
+        if (!highlightedNode) return;
+        const domNode = getGraphDOMNode(highlightedNode.nodeId);
         zoomToNode(domNode);
-    }, [props.highlightedNode]);
+    }, [highlightedNode]);
 
     return (
         <div style={{ position: "relative", padding: "16px" }}>
@@ -176,4 +175,26 @@ const SvgGraph = (props) => {
         return found;
     }
 };
+
+SvgGraph.propTypes = {
+    dates: PropTypes.array,
+    highlightedNode: PropTypes.shape({
+        nodeId: PropTypes.string,
+        rank: PropTypes.number,
+    }),
+    nodeHash: PropTypes.array,
+    nodeList: PropTypes.array,
+    onSelectNode: PropTypes.func,
+    persons: PropTypes.array,
+    places: PropTypes.array,
+    sectionId: PropTypes.string,
+    selectedRank: PropTypes.number,
+    selectedSentence: PropTypes.shape({
+        startId: PropTypes.string,
+        startRank: PropTypes.number,
+        endRank: PropTypes.number,
+    }),
+    selectedTimestamp: PropTypes.string,
+};
+
 export default SvgGraph;

--- a/src/components/Edition/SvgGraph.js
+++ b/src/components/Edition/SvgGraph.js
@@ -182,7 +182,7 @@ SvgGraph.propTypes = {
         nodeId: PropTypes.string,
         rank: PropTypes.number,
     }),
-    nodeHash: PropTypes.array,
+    nodeHash: PropTypes.object,
     nodeList: PropTypes.array,
     onSelectNode: PropTypes.func,
     persons: PropTypes.array,

--- a/src/components/Edition/TextPane.js
+++ b/src/components/Edition/TextPane.js
@@ -41,8 +41,8 @@ const TextPane = (props) => {
                 // the translation and armenian texts are encode with nodeId and rank
                 let rank =
                     reading === "Translation"
-                        ? attribs.id.split("-")[0]
-                        : attribs.key;
+                        ? parseInt(attribs.id.split("-")[0])
+                        : parseInt(attribs.key);
                 let nodeId =
                     reading === "Translation"
                         ? attribs.id.split("-")[1]
@@ -87,9 +87,7 @@ const TextPane = (props) => {
                             : false
                         : false;
                     if (isSearchTerm) onSelectNode(nodeId);
-                    let atRank = selectedRank
-                        ? selectedRank === parseInt(rank)
-                        : false;
+                    let atRank = selectedRank ? selectedRank === rank : false;
                     let selected = selectedNode
                         ? selectedNode.nodeId === nodeId
                         : false;
@@ -114,9 +112,8 @@ const TextPane = (props) => {
                           })
                         : false;
                     let inSelectedSentence = selectedSentence
-                        ? parseInt(rank) >=
-                              parseInt(selectedSentence.startRank) &&
-                          parseInt(rank) <= parseInt(selectedSentence.endRank)
+                        ? rank >= selectedSentence.startRank &&
+                          rank <= selectedSentence.endRank
                         : false;
                     let textStyle = {
                         color: "black",

--- a/src/components/Edition/TextPane.js
+++ b/src/components/Edition/TextPane.js
@@ -314,7 +314,7 @@ TextPane.propTypes = {
     dates: PropTypes.array,
     graphVisible: PropTypes.bool,
     manuscripts: PropTypes.array,
-    nodeHash: PropTypes.array,
+    nodeHash: PropTypes.object,
     onSelectLocation: PropTypes.func,
     onSelectNode: PropTypes.func,
     onSelectSentence: PropTypes.func,

--- a/src/components/Edition/TextPane.js
+++ b/src/components/Edition/TextPane.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import Parser, { domToReact } from "html-react-parser";
 import * as DataApi from "../../utils/Api";
 import Typography from "@material-ui/core/Typography";
@@ -23,6 +24,9 @@ const TextPane = (props) => {
         manuscripts,
         nodeHash,
         selectedTimestamp,
+        selectedRank,
+        selectedNode,
+        sections,
     } = props;
 
     const [enTitle, setEnTitle] = useState();
@@ -46,8 +50,8 @@ const TextPane = (props) => {
 
                 // this can be further refactored - it was in transition...
                 if (reading === "Translation") {
-                    let selected = props.selectedSentence
-                        ? props.selectedSentence.startId === nodeId
+                    let selected = selectedSentence
+                        ? selectedSentence.startId === nodeId
                         : false;
                     let searchedFor = searchTerm
                         ? children[0].data.indexOf(searchTerm) > -1
@@ -83,11 +87,11 @@ const TextPane = (props) => {
                             : false
                         : false;
                     if (isSearchTerm) onSelectNode(nodeId);
-                    let atRank = props.selectedRank
-                        ? props.selectedRank === parseInt(rank)
+                    let atRank = selectedRank
+                        ? selectedRank === parseInt(rank)
                         : false;
-                    let selected = props.selectedNode
-                        ? props.selectedNode.nodeId === nodeId
+                    let selected = selectedNode
+                        ? selectedNode.nodeId === nodeId
                         : false;
                     let person = persons
                         ? persons.find((p) => {
@@ -109,7 +113,7 @@ const TextPane = (props) => {
                               return isWithinRange(d.begin, d.end, nodeId);
                           })
                         : false;
-                    let inSelectedSentence = props.selectedSentence
+                    let inSelectedSentence = selectedSentence
                         ? parseInt(rank) >=
                               parseInt(selectedSentence.startRank) &&
                           parseInt(rank) <= parseInt(selectedSentence.endRank)
@@ -175,27 +179,27 @@ const TextPane = (props) => {
     };
 
     useEffect(() => {
-        if (!props.sections) return;
-        const selectedSection = props.sections.find((s) => {
+        if (!sections) return;
+        const selectedSection = sections.find((s) => {
             return s.sectionId === sectionId;
         });
         if (selectedSection) {
             setEnTitle(selectedSection.englishTitle);
             setArTitle(selectedSection.armenianTitle);
         }
-    }, [sectionId, props.sections]);
+    }, [sectionId, sections]);
 
     useEffect(() => {
         DataApi.getReading(
             sectionId,
-            props.reading,
+            reading,
             (html) => {
                 let parsed = Parser(html, parserOptions);
                 setTextHTML(parsed);
             },
             selectedTimestamp
         );
-        lookupManuscriptName(props.reading);
+        lookupManuscriptName(reading);
     }, [props, selectedTimestamp]);
 
     return (
@@ -303,6 +307,34 @@ const TextPane = (props) => {
             if (graphVisible) onSelectNode(node);
         }
     }
+};
+
+TextPane.propTypes = {
+    comments: PropTypes.array,
+    dates: PropTypes.array,
+    graphVisible: PropTypes.boolean,
+    manuscripts: PropTypes.array,
+    nodeHash: PropTypes.array,
+    onSelectLocation: PropTypes.func,
+    onSelectNode: PropTypes.func,
+    onSelectSentence: PropTypes.func,
+    persons: PropTypes.array,
+    places: PropTypes.array,
+    reading: PropTypes.string,
+    searchTerm: PropTypes.string,
+    sectionId: PropTypes.string,
+    sections: PropTypes.array,
+    selectedNode: PropTypes.shape({
+        nodeId: PropTypes.string,
+        rank: PropTypes.number,
+    }),
+    selectedRank: PropTypes.number,
+    selectedSentence: PropTypes.shape({
+        startId: PropTypes.string,
+        startRank: PropTypes.number,
+        endRank: PropTypes.number,
+    }),
+    selectedTimestamp: PropTypes.string,
 };
 
 export default TextPane;

--- a/src/components/Edition/TextPane.js
+++ b/src/components/Edition/TextPane.js
@@ -312,7 +312,7 @@ const TextPane = (props) => {
 TextPane.propTypes = {
     comments: PropTypes.array,
     dates: PropTypes.array,
-    graphVisible: PropTypes.boolean,
+    graphVisible: PropTypes.bool,
     manuscripts: PropTypes.array,
     nodeHash: PropTypes.array,
     onSelectLocation: PropTypes.func,

--- a/src/components/Edition/ViewOptions.js
+++ b/src/components/Edition/ViewOptions.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Typography from "@material-ui/core/Typography";
 import ExpansionPanel from "@material-ui/core/ExpansionPanel";
 import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
@@ -12,30 +13,28 @@ import FormControl from "@material-ui/core/FormControl";
 import InputLabel from "@material-ui/core/InputLabel";
 import Checkbox from "@material-ui/core/Checkbox";
 
-const ViewOptions = (props) => {
-    const {
-        onToggleGraph,
-        graphVisible,
-        viewport,
-        witnesses,
-        leftReading,
-        rightReading,
-        timestampsList,
-        selectedTimestamp,
-        onTimestampSelect,
-        onSelectLeftReading,
-        onSelectRightReading,
-        personsVisible,
-        onTogglePersons,
-        placesVisible,
-        onTogglePlaces,
-        datesVisible,
-        onToggleDates,
-        isExpanded,
-        setIsExpanded,
-        manuscripts,
-    } = props;
-
+const ViewOptions = ({
+    onToggleGraph,
+    graphVisible,
+    viewport,
+    witnesses,
+    leftReading,
+    rightReading,
+    timestampsList,
+    selectedTimestamp,
+    onTimestampSelect,
+    onSelectLeftReading,
+    onSelectRightReading,
+    personsVisible,
+    onTogglePersons,
+    placesVisible,
+    onTogglePlaces,
+    datesVisible,
+    onToggleDates,
+    isExpanded,
+    setIsExpanded,
+    manuscripts,
+}) => {
     return (
         <ExpansionPanel
             style={{
@@ -216,5 +215,30 @@ const ViewOptions = (props) => {
             </ExpansionPanelDetails>
         </ExpansionPanel>
     );
+};
+ViewOptions.propTypes = {
+    datesVisible: PropTypes.bool,
+    graphVisible: PropTypes.bool,
+    isExpanded: PropTypes.bool,
+    leftReading: PropTypes.string,
+    manuscripts: PropTypes.array,
+    onSelectLeftReading: PropTypes.func,
+    onSelectRightReading: PropTypes.func,
+    onTimestampSelect: PropTypes.func,
+    onToggleDates: PropTypes.func,
+    onToggleGraph: PropTypes.func,
+    onTogglePersons: PropTypes.func,
+    onTogglePlaces: PropTypes.func,
+    personsVisible: PropTypes.bool,
+    placesVisible: PropTypes.bool,
+    rightReading: PropTypes.string,
+    selectedTimestamp: PropTypes.string,
+    setIsExpanded: PropTypes.func,
+    timestampsList: PropTypes.array,
+    viewport: PropTypes.shape({
+        width: PropTypes.number,
+        height: PropTypes.number,
+    }),
+    witnesses: PropTypes.array,
 };
 export default ViewOptions;

--- a/src/components/Edition/ViewOptions.js
+++ b/src/components/Edition/ViewOptions.js
@@ -143,7 +143,7 @@ const ViewOptions = ({
                     </Select>
                 </FormControl>
 
-                <div style={{ height: "8px" }}></div>
+                <div style={{ height: "8px" }} />
 
                 <FormControl>
                     <InputLabel style={{ fontSize: "16px", paddingLeft: 10 }}>

--- a/src/components/Edition/ViewOptions.js
+++ b/src/components/Edition/ViewOptions.js
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Typography from "@material-ui/core/Typography";
-import ExpansionPanel from "@material-ui/core/ExpansionPanel";
-import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
-import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import Accordion from "@material-ui/core/Accordion";
+import AccordionSummary from "@material-ui/core/AccordionSummary";
+import AccordionDetails from "@material-ui/core/AccordionDetails";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import Switch from "@material-ui/core/Switch";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
@@ -36,7 +36,7 @@ const ViewOptions = ({
     manuscripts,
 }) => {
     return (
-        <ExpansionPanel
+        <Accordion
             style={{
                 marginLeft: "16px",
                 marginBottom: "8px",
@@ -48,10 +48,10 @@ const ViewOptions = ({
                 setIsExpanded(ex);
             }}
         >
-            <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 <Typography variant="h6">{"View Options"}</Typography>
-            </ExpansionPanelSummary>
-            <ExpansionPanelDetails
+            </AccordionSummary>
+            <AccordionDetails
                 style={{
                     display: "flex",
                     flexDirection: "column",
@@ -204,7 +204,10 @@ const ViewOptions = ({
                         >
                             {timestampsList.map((timestamp) => {
                                 return (
-                                    <MenuItem value={timestamp.value}>
+                                    <MenuItem
+                                        key={timestamp.value}
+                                        value={timestamp.value}
+                                    >
                                         {timestamp.label}
                                     </MenuItem>
                                 );
@@ -212,8 +215,8 @@ const ViewOptions = ({
                         </Select>
                     )}
                 </FormControl>
-            </ExpansionPanelDetails>
-        </ExpansionPanel>
+            </AccordionDetails>
+        </Accordion>
     );
 };
 ViewOptions.propTypes = {

--- a/src/components/Edition/index.js
+++ b/src/components/Edition/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import withWidth from "@material-ui/core/withWidth"; // used by grid
 import SectionList from "./SectionList";
@@ -431,4 +432,23 @@ const Edition = (props) => {
         props.history.push(`/Edition/${previous.sectionId}`);
     }
 };
+
+Edition.propTypes = {
+    history: PropTypes.shape({
+        push: PropTypes.func.isRequired,
+    }).isRequired,
+    manuscripts: PropTypes.array,
+    onSearch: PropTypes.func,
+    onTimestampSelect: PropTypes.func,
+    searchTerm: PropTypes.string,
+    sections: PropTypes.array,
+    selectedTimestamp: PropTypes.string,
+    timestampsList: PropTypes.array,
+    viewport: PropTypes.shape({
+        width: PropTypes.number,
+        height: PropTypes.number,
+    }),
+    witnesses: PropTypes.array,
+};
+
 export default withWidth()(withRouter(Edition));

--- a/src/components/Edition/index.js
+++ b/src/components/Edition/index.js
@@ -358,14 +358,14 @@ const Edition = (props) => {
                 setSelectedRank(null);
                 return;
             }
-        setSelectedRank(node.rank);
+        setSelectedRank(parseInt(node.rank));
         setSelectedNode(node);
     }
 
     function handleSelectSentence(start, end) {
-        const startRank = start.split("-")[0];
+        const startRank = parseInt(start.split("-")[0]);
         const startNodeId = start.split("-")[1];
-        const endRank = end.split("-")[0];
+        const endRank = parseInt(end.split("-")[0]);
         const endNodeId = end.split("-")[1];
 
         if (selectedSentence) {
@@ -411,7 +411,7 @@ const Edition = (props) => {
             return;
         }
         setSelectedNode(null);
-        setSelectedRank(rank);
+        setSelectedRank(parseInt(rank));
     }
 
     function nextSection() {

--- a/src/components/EditionLanding.js
+++ b/src/components/EditionLanding.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Card from "@material-ui/core/Card";
 import CardActions from "@material-ui/core/CardActions";
 import Button from "@material-ui/core/Button";
@@ -7,13 +8,11 @@ import { Grid } from "@material-ui/core";
 import { Link } from "react-router-dom";
 import Header from "./Header";
 
-const EditionLanding = (props) => {
+const EditionLanding = ({ onSearch }) => {
     const cardStyle = {
         width: "210px",
         height: "210px",
     };
-
-    const { onSearch } = props;
 
     return (
         <Grid container>
@@ -174,6 +173,10 @@ const EditionLanding = (props) => {
                   </Grid> */}
         </Grid>
     );
+};
+
+EditionLanding.propTypes = {
+    onSearch: PropTypes.func,
 };
 
 export default EditionLanding;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,10 +1,9 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import Navigation from "./Navigation";
 
-const Header = (props) => {
-    const { onSearch } = props;
-
+const Header = ({ onSearch }) => {
     return (
         <Grid container spacing={0}>
             <Grid item xs={12}>
@@ -26,4 +25,9 @@ const Header = (props) => {
         </Grid>
     );
 };
+
+Header.propTypes = {
+    onSearch: PropTypes.func,
+};
+
 export default Header;

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from "react";
+import PropTypes from "prop-types";
 import TextPane from "./Edition/TextPane";
 import Typography from "@material-ui/core/Typography";
 import { Grid } from "@material-ui/core";
@@ -6,9 +7,7 @@ import Header from "./Header";
 import Button from "@material-ui/core/Button";
 import { Link } from "react-router-dom";
 
-const HomePage = (props) => {
-    const { sections, onSearch, selectedTimestamp } = props;
-
+const HomePage = ({ sections, onSearch, selectedTimestamp }) => {
     return (
         <Fragment>
             <Header onSearch={onSearch} />
@@ -101,4 +100,11 @@ const HomePage = (props) => {
         </Fragment>
     );
 };
+
+HomePage.propTypes = {
+    onSearch: PropTypes.func,
+    sections: PropTypes.array,
+    selectedTimestamp: PropTypes.string,
+};
+
 export default HomePage;

--- a/src/components/Manuscript/ManuscriptView.js
+++ b/src/components/Manuscript/ManuscriptView.js
@@ -60,7 +60,7 @@ const ManuscriptView = (props) => {
                         marginLeft: 20,
                         overflowWrap: "break-word",
                     }}
-                ></Typography>
+                 />
             </Grid>
             <Hidden xsDown>
                 <Grid item md={6}>

--- a/src/components/Manuscript/index.js
+++ b/src/components/Manuscript/index.js
@@ -1,10 +1,10 @@
 import React, { Fragment } from "react";
+import PropTypes from "prop-types";
 import Header from "../Header";
 import { Link } from "react-router-dom";
 import CloudDownloadIcon from "@material-ui/icons/CloudDownload";
 
-const ManuscriptPage = (props) => {
-    const { onSearch } = props;
+const ManuscriptPage = ({ onSearch }) => {
     return (
         <Fragment>
             <Header onSearch={onSearch} />
@@ -1101,4 +1101,9 @@ const ManuscriptPage = (props) => {
         </Fragment>
     );
 };
+
+ManuscriptPage.propTypes = {
+    onSearch: PropTypes.func,
+};
+
 export default ManuscriptPage;

--- a/src/components/Manuscript/index.js
+++ b/src/components/Manuscript/index.js
@@ -42,7 +42,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                             width: "80px",
                                             marginLeft: "24px",
                                         }}
-                                        to="/ManuscriptView/Bz430"
+                                        to="/Manuscripts/Bz430"
                                     >
                                         {"read transcription"}
                                     </Link>
@@ -73,7 +73,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/Bz449"
+                                    to="/Manuscripts/Bz449"
                                 >
                                     {"read transcription"}
                                 </Link>
@@ -103,7 +103,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/Bz644"
+                                    to="/Manuscripts/Bz644"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -141,7 +141,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/L5260"
+                                    to="/Manuscripts/L5260"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -180,7 +180,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M1731"
+                                    to="/Manuscripts/M1731"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -211,7 +211,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M1767"
+                                    to="/Manuscripts/M1767"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -242,7 +242,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M1768"
+                                    to="/Manuscripts/M1768"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -273,7 +273,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M1769"
+                                    to="/Manuscripts/M1769"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -307,7 +307,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M1775"
+                                    to="/Manuscripts/M1775"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -339,7 +339,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M1896"
+                                    to="/Manuscripts/M1896"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -370,7 +370,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M2644"
+                                    to="/Manuscripts/M2644"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -402,7 +402,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M2855"
+                                    to="/Manuscripts/M2855"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -436,7 +436,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M2899"
+                                    to="/Manuscripts/M2899"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -467,7 +467,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M3071"
+                                    to="/Manuscripts/M3071"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -501,7 +501,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M3380"
+                                    to="/Manuscripts/M3380"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -532,7 +532,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M3519"
+                                    to="/Manuscripts/M3519"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -566,7 +566,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M3520"
+                                    to="/Manuscripts/M3520"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -597,7 +597,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M5587"
+                                    to="/Manuscripts/M5587"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -628,7 +628,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M6605"
+                                    to="/Manuscripts/M6605"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -660,7 +660,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M6686"
+                                    to="/Manuscripts/M6686"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -693,7 +693,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/M8232"
+                                    to="/Manuscripts/M8232"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -733,7 +733,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/Ox-e.32"
+                                    to="/Manuscripts/Ox-e.32"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -772,7 +772,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/V913"
+                                    to="/Manuscripts/V913"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -803,7 +803,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/V901"
+                                    to="/Manuscripts/V901"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -835,7 +835,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/V913"
+                                    to="/Manuscripts/V913"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -867,7 +867,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/V917"
+                                    to="/Manuscripts/V917"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -906,7 +906,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/W243"
+                                    to="/Manuscripts/W243"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -938,7 +938,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/W246"
+                                    to="/Manuscripts/W246"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -969,7 +969,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/W574"
+                                    to="/Manuscripts/W574"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -1007,7 +1007,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/W574"
+                                    to="/Manuscripts/W574"
                                     color="secondary"
                                 >
                                     {"read transcription"}
@@ -1037,7 +1037,7 @@ const ManuscriptPage = ({ onSearch }) => {
                                         width: "80px",
                                         marginLeft: "24px",
                                     }}
-                                    to="/ManuscriptView/W574"
+                                    to="/Manuscripts/W574"
                                     color="secondary"
                                 >
                                     {"read transcription"}

--- a/src/components/Methods.js
+++ b/src/components/Methods.js
@@ -1,9 +1,8 @@
 import React, { Fragment } from "react";
+import PropTypes from "prop-types";
 import Header from "./Header";
 
-const MethodsPage = (props) => {
-    const { onSearch } = props;
-
+const MethodsPage = ({ onSearch }) => {
     const dejaVuStyle = {
         fontFamily: "Menlo, Consolas, DejaVu Sans Mono monospace",
     };
@@ -469,4 +468,9 @@ const MethodsPage = (props) => {
         </Fragment>
     );
 };
+
+MethodsPage.propTypes = {
+    onSearch: PropTypes.func,
+};
+
 export default MethodsPage;

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, Fragment } from "react";
+import PropTypes from "prop-types";
 import AppBar from "@material-ui/core/AppBar";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
@@ -197,7 +198,7 @@ const Navigation = (props) => {
         setSearchQuery(e.target.value);
     }
 
-    function handlePressEnter(e, value) {
+    function handlePressEnter() {
         onSearch(searchQuery);
         setSearchQuery("");
         props.history.push("/Search");
@@ -207,4 +208,12 @@ const Navigation = (props) => {
         setTabIndex(value);
     }
 };
+
+Navigation.propTypes = {
+    history: PropTypes.shape({
+        push: PropTypes.func.isRequired,
+    }).isRequired,
+    onSearch: PropTypes.func,
+};
+
 export default withRouter(Navigation);

--- a/src/components/RootContainer.js
+++ b/src/components/RootContainer.js
@@ -3,7 +3,7 @@ import * as DataApi from "./../utils/Api";
 import Routes from "./Routes";
 import { HashRouter as Router } from "react-router-dom";
 
-const RootContainer = (props) => {
+const RootContainer = () => {
     const [sectionList, setSectionList] = useState([]);
     const [witnessList, setWitnessList] = useState([]);
     const [manuscriptLookup, setManuscriptLookup] = useState([]);

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -134,10 +134,10 @@ const Routes = ({
                 <Route path="/Methods">
                     <MethodsPage onSearch={setSearchTerm} />
                 </Route>
-                <Route path="/Manuscripts">
+                <Route path="/Manuscripts" exact>
                     <ManuscriptPage onSearch={setSearchTerm} />
                 </Route>
-                <Route path="/ManuscriptView/:manuscriptId" exact>
+                <Route path="/Manuscripts/:manuscriptId" exact>
                     <ManuscriptView onSearch={setSearchTerm} />
                 </Route>
                 <Route path="/Home" exact>

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import AboutPage from "./About";
 import MethodsPage from "./Methods";
 import ManuscriptPage from "./Manuscript";
@@ -16,16 +17,15 @@ import Visualizations from "./Visualizations";
 import Timeline from "./Visualizations/Timeline";
 import MapView from "./Visualizations/Map";
 
-const Routes = (props) => {
+const Routes = ({
+    sections,
+    witnesses,
+    manuscripts,
+    timestampsList,
+    selectedTimestamp,
+    onTimestampSelect,
+}) => {
     const viewport = useWindowSize();
-    const {
-        sections,
-        witnesses,
-        manuscripts,
-        timestampsList,
-        selectedTimestamp,
-        onTimestampSelect,
-    } = props;
 
     const [searchTerm, setSearchTerm] = useState("");
     const [translationDictionary, setTranslationDictionary] = useState([]);
@@ -193,4 +193,14 @@ const Routes = (props) => {
         </ThemeProvider>
     );
 };
+
+Routes.propTypes = {
+    manuscripts: PropTypes.array,
+    onTimestampSelect: PropTypes.func,
+    sections: PropTypes.array,
+    selectedTimestamp: PropTypes.string,
+    timestampsList: PropTypes.array,
+    witnesses: PropTypes.array,
+};
+
 export default Routes;

--- a/src/components/SearchInupt.js
+++ b/src/components/SearchInupt.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { fade, makeStyles } from "@material-ui/core/styles";
 import InputBase from "@material-ui/core/InputBase";
 import SearchIcon from "@material-ui/icons/Search";
@@ -65,9 +66,8 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-export default function SearchInput(props) {
+export default function SearchInput({ onPressEnter, onChange, searchQuery }) {
     const classes = useStyles();
-    const { onPressEnter, onChange, searchQuery } = props;
 
     return (
         <div className={classes.search}>
@@ -93,3 +93,9 @@ export default function SearchInput(props) {
         if (e.key === "Enter") onPressEnter();
     }
 }
+
+SearchInput.propTypes = {
+    onChange: PropTypes.func,
+    onPressEnter: PropTypes.func,
+    searchQuery: PropTypes.string,
+};

--- a/src/components/Visualizations/Map.js
+++ b/src/components/Visualizations/Map.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from "react";
+import PropTypes from "prop-types";
 import mapboxgl from "mapbox-gl";
 import EditionHeader from "./../Edition/EditionHeader";
 import { withRouter } from "react-router-dom";
@@ -8,9 +9,8 @@ import Paper from "@material-ui/core/Paper";
 
 mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_TOKEN;
 
-const MapView = (props) => {
+const MapView = ({ geoData, locationLookup, sections, onSearch }) => {
     const mapRef = useRef();
-    const { geoData, locationLookup, sections, onSearch } = props;
     const homePath =
         window.location.hostname === "localhost"
             ? "/"
@@ -349,4 +349,12 @@ const MapView = (props) => {
         return polygonArray;
     }
 };
+
+MapView.propTypes = {
+    geoData: PropTypes.array,
+    locationLookup: PropTypes.array,
+    onSearch: PropTypes.func,
+    sections: PropTypes.array,
+};
+
 export default withRouter(MapView);

--- a/src/components/Visualizations/Map.js
+++ b/src/components/Visualizations/Map.js
@@ -192,7 +192,7 @@ const MapView = ({ geoData, locationLookup, sections, onSearch }) => {
                     top: "0px",
                     width: "100%",
                 }}
-            ></div>
+            />
             <Paper
                 elevation={2}
                 style={{

--- a/src/components/Visualizations/Timeline.js
+++ b/src/components/Visualizations/Timeline.js
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
+import PropTypes from "prop-types";
 import EditionHeader from "./../Edition/EditionHeader";
 import Chart from "react-google-charts";
 import { Redirect, withRouter } from "react-router-dom";
 
-const Timeline = (props) => {
-    const { timelineData } = props;
-
+const Timeline = ({ onSearch, timelineData }) => {
     const [redirectPath, setRedirectPath] = useState();
 
     // only want to show events that have an earliest and/or latest date -- can't show
@@ -67,7 +66,7 @@ const Timeline = (props) => {
 
     return (
         <>
-            <EditionHeader onSearch={props.onSearch} />
+            <EditionHeader onSearch={onSearch} />
             <h1 style={{ margin: 40, textAlign: "center" }}>
                 {" "}
                 <i>Timeline</i>
@@ -114,6 +113,11 @@ const Timeline = (props) => {
             />
         </>
     );
+};
+
+Timeline.propTypes = {
+    onSearch: PropTypes.func,
+    timelineData: PropTypes.array,
 };
 
 export default withRouter(Timeline);

--- a/src/components/Visualizations/index.js
+++ b/src/components/Visualizations/index.js
@@ -1,6 +1,6 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Header from "../Header";
-
 import {
     Container,
     Card,
@@ -11,9 +11,7 @@ import {
     useMediaQuery,
 } from "@material-ui/core";
 
-const Visualizations = (props) => {
-    const { onSearch } = props;
-
+const Visualizations = ({ onSearch }) => {
     const smallScreen = useMediaQuery("(min-width:600px)");
 
     const containerStyle = {
@@ -97,6 +95,10 @@ const Visualizations = (props) => {
             </Container>
         </>
     );
+};
+
+Visualizations.propTypes = {
+    onSearch: PropTypes.func,
 };
 
 export default Visualizations;


### PR DESCRIPTION
## In this PR

- Define `PropTypes` for all components
- Resolve console and linter warnings:
  - Rename `ManuscriptView/:id` route to `Manuscripts/:id` to match the nav item
  - Rename deprecated Material UI `ExpansionPanel` to new `Accordion`
  - Fix undefined errors in data generation scripts
- Improve readme