### PR TITLE
Fix lemma text on root path (#125)

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -38,7 +38,11 @@ const Navigation = (props) => {
 
     useEffect(() => {
         let pageName = window.location.hash.split("/")[1];
-        setTabIndex(`#/${pageName}`);
+        if (!pageName || pageName.includes(process.env.REACT_APP_HOMEPATH)) {
+            setTabIndex(`#/Home`);
+        } else {
+            setTabIndex(`#/${pageName}`);
+        }
     }, []);
 
     const StyledTabs = withStyles({
@@ -147,8 +151,8 @@ const Navigation = (props) => {
                         >
                             <StyledTab
                                 label="Home"
-                                href="#/home"
-                                value="#/home"
+                                href="#/Home"
+                                value="#/Home"
                             />
                             <StyledTab
                                 label="About"

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -184,11 +184,21 @@ const Routes = ({
                     <Visualizations onSearch={setSearchTerm} />
                 </Route>
                 <Route path="/" exact>
-                    <HomePage onSearch={setSearchTerm} sections={sections} />
+                    <HomePage
+                        onSearch={setSearchTerm}
+                        sections={sections}
+                        selectedTimestamp={selectedTimestamp}
+                    />
                 </Route>
-                <Route path="/ChronicleME" exact>
-                    <HomePage onSearch={setSearchTerm} sections={sections} />
-                </Route>
+                {process.env.REACT_APP_HOMEPATH && (
+                    <Route path={process.env.REACT_APP_HOMEPATH} exact>
+                        <HomePage
+                            onSearch={setSearchTerm}
+                            sections={sections}
+                            selectedTimestamp={selectedTimestamp}
+                        />
+                    </Route>
+                )}
             </Switch>
         </ThemeProvider>
     );


### PR DESCRIPTION
## In this PR

- Per #125 
  - Fix text not appearing when path is just the root path of the app (i.e. `/#`)
- Fix bug where "Home" tab was not visibly selected when on `/#` or `REACT_APP_HOMEPATH`