### PR TITLE
Fixing hardcoded section ids

### DIFF
--- a/src/components/Edition/index.js
+++ b/src/components/Edition/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import withWidth from "@material-ui/core/withWidth"; // used by grid
@@ -32,6 +32,13 @@ const Edition = (props) => {
     let { sectionID } = useParams();
     let { witnessID } = useParams();
 
+    const sectionIndex = useMemo(() =>
+        sections && sections.find((s) => (s.sectionId === sectionID))
+            ? sections.find((s) => (s.sectionId === sectionID)).index
+            : null,
+        [sectionID]
+    );
+
     const [selectedNode, setSelectedNode] = useState(null);
     const [selectedSentence, setSelectedSentence] = useState({});
     const [selectedRank, setSelectedRank] = useState();
@@ -54,6 +61,16 @@ const Edition = (props) => {
     );
     const [rightReading, setRightReading] = useState("Translation");
     const [isExpanded, setIsExpanded] = useState(false);
+
+    useEffect(() => {
+        //update the section ID if necessary if the timestamp is changed
+        if (sections && !sections.find((s) => (s.sectionId === sectionID))) {
+            //in this case we'll default to navigating to the section in the new list 
+            // that shares the index of the current section in the old list
+            const newSectionID = sections?.length ? (sections.find((s) => (s.index === sectionIndex))?.sectionId || sections[0].sectionId) : null;
+            newSectionID && props.history.push(`/Edition/${newSectionID}`);
+        }
+    }, [sections]);
 
     useEffect(() => {
         setSelectedSentence(null);

--- a/src/components/EditionLanding.js
+++ b/src/components/EditionLanding.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import Card from "@material-ui/core/Card";
 import CardActions from "@material-ui/core/CardActions";
@@ -8,11 +8,19 @@ import { Grid } from "@material-ui/core";
 import { Link } from "react-router-dom";
 import Header from "./Header";
 
-const EditionLanding = ({ onSearch }) => {
+const EditionLanding = ({ onSearch, sections }) => {
     const cardStyle = {
         width: "210px",
         height: "210px",
     };
+
+    // the years at which the books are split
+    const milestones = [500, 550, 577];
+
+    const book1Id = useMemo(() => (sections && sections[0].sectionId), [sections]);
+    const book2Id = useMemo(() => (sections && sections.find((s) => (Number(s.milestone) >= milestones[0]))?.sectionId), [sections]);
+    const book3Id = useMemo(() => (sections && sections.find((s) => (Number(s.milestone) >= milestones[1]))?.sectionId), [sections]);
+    const continuationId = useMemo(() => (sections && sections.find((s) => (Number(s.milestone) >= milestones[2]))?.sectionId), [sections]);
 
     return (
         <Grid container>
@@ -79,7 +87,7 @@ const EditionLanding = ({ onSearch }) => {
                                             <Button
                                                 size="large"
                                                 component={Link}
-                                                to="/Edition/1019321"
+                                                to={`/Edition/${book1Id}`}
                                                 color="secondary"
                                             >
                                                 <Typography variant="body2">
@@ -103,7 +111,7 @@ const EditionLanding = ({ onSearch }) => {
                                             <Button
                                                 size="large"
                                                 component={Link}
-                                                to="/Edition/955909"
+                                                to={`/Edition/${book2Id}`}
                                                 color="secondary"
                                             >
                                                 <Typography variant="body2">
@@ -127,7 +135,7 @@ const EditionLanding = ({ onSearch }) => {
                                             <Button
                                                 size="large"
                                                 component={Link}
-                                                to="/Edition/1101117"
+                                                to={`/Edition/${book3Id}`}
                                                 color="secondary"
                                             >
                                                 <Typography variant="body2">
@@ -151,7 +159,7 @@ const EditionLanding = ({ onSearch }) => {
                                             <Button
                                                 size="large"
                                                 component={Link}
-                                                to="/Edition/1041054"
+                                                to={`/Edition/${continuationId}`}
                                                 color="secondary"
                                             >
                                                 <Typography variant="body2">
@@ -177,6 +185,7 @@ const EditionLanding = ({ onSearch }) => {
 
 EditionLanding.propTypes = {
     onSearch: PropTypes.func,
+    sections: PropTypes.array
 };
 
 export default EditionLanding;

--- a/src/components/EditionLanding.js
+++ b/src/components/EditionLanding.js
@@ -17,9 +17,9 @@ const EditionLanding = ({ onSearch, sections }) => {
     // the years at which the books are split
     const milestones = [500, 550, 577];
 
-    const book1Id = useMemo(() => (sections && sections[0].sectionId), [sections]);
-    const book2Id = useMemo(() => (sections && sections.find((s) => (Number(s.milestone) >= milestones[0]))?.sectionId), [sections]);
-    const book3Id = useMemo(() => (sections && sections.find((s) => (Number(s.milestone) >= milestones[1]))?.sectionId), [sections]);
+    const book1Id = useMemo(() => (sections?.length && sections[0].sectionId), [sections]);
+    const book2Id = useMemo(() => (sections?.length && sections.find((s) => (Number(s.milestone) >= milestones[0]))?.sectionId), [sections]);
+    const book3Id = useMemo(() => (sections?.length && sections.find((s) => (Number(s.milestone) >= milestones[1]))?.sectionId), [sections]);
     const continuationId = useMemo(() => (sections && sections.find((s) => (Number(s.milestone) >= milestones[2]))?.sectionId), [sections]);
 
     return (

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React, { Fragment, useMemo } from "react";
 import PropTypes from "prop-types";
 import TextPane from "./Edition/TextPane";
 import Typography from "@material-ui/core/Typography";
@@ -8,6 +8,8 @@ import Button from "@material-ui/core/Button";
 import { Link } from "react-router-dom";
 
 const HomePage = ({ sections, onSearch, selectedTimestamp }) => {
+    const firstSectionId = useMemo(() => (sections?.length && sections[0].sectionId), [sections]);
+
     return (
         <Fragment>
             <Header onSearch={onSearch} />
@@ -59,7 +61,7 @@ const HomePage = ({ sections, onSearch, selectedTimestamp }) => {
                                 onSelectPerson={() => {}}
                                 onSelectSentence={() => {}}
                                 reading="Lemma Text"
-                                sectionId="1019321"
+                                sectionId={firstSectionId}
                                 sections={sections}
                                 selectedTimestamp={selectedTimestamp}
                             />
@@ -72,7 +74,7 @@ const HomePage = ({ sections, onSearch, selectedTimestamp }) => {
                                 onSelectPerson={() => {}}
                                 onSelectSentence={() => {}}
                                 reading="Translation"
-                                sectionId="1019321"
+                                sectionId={firstSectionId}
                                 sections={sections}
                                 selectedTimestamp={selectedTimestamp}
                             />
@@ -89,7 +91,7 @@ const HomePage = ({ sections, onSearch, selectedTimestamp }) => {
                                 color="secondary"
                                 component={Link}
                                 size="large"
-                                to="/Edition/1019321"
+                                to={`/Edition/${firstSectionId}`}
                             >
                                 <Typography variant="h5">
                                     {"Read on..."}


### PR DESCRIPTION
### In this PR
Addresses Issue #143 by updating how the section ID is determined in three different places:
- On the home page, the ID of the first section is grabbed from the `sections` prop rather than being hardcoded;
- On the edition landing page, links to the first sections of books 1, 2, 3 and the continuation are generated from the `sections` prop using the `milestone` field;
- In the edition viewer, a check is added to update the `sectionID` parameter in the URL if necessary when a different timestamp of data is selected.

### Notes/questions
With the timestamp selection, should the `sectionID` ideally be updated to...
- ...the section with the same value in the `index` field (this is what I went with for now),
- ...the section with the same actual index in the list,
- ....a secret third thing?