### PR TITLE
Updates to data fetching

### DIFF
--- a/script/generateAllWitnessLunrData.js
+++ b/script/generateAllWitnessLunrData.js
@@ -9,7 +9,7 @@ async function generateLunrSource(timestamp) {
     const startTime = moment();
     console.log("started", startTime.format("hh:mm:ss"));
     const config = loadConfig();
-    const baseURL = `${config.options.repository}/tradition/${config.options.tradition_id}`;
+    const baseURL = `${config.options.repository}/${config.options.tradition_id}`;
     const auth = config.auth;
     const outdir = `public/data/data_${timestamp}`;
     const lunrData = [];
@@ -106,7 +106,7 @@ async function generateLunrSource(timestamp) {
             sigil === "Lemma text"
                 ? (r) => r.is_lemma && !r.is_start && !r.is_end
                 : (r) =>
-                      r.witnesses.includes(sigil) && !r.is_start && !r.is_end;
+                    r.witnesses.includes(sigil) && !r.is_start && !r.is_end;
         const witReadings = readings.filter(filterCondition);
         witReadings.sort((first, second) => {
             return first.rank - second.rank;
@@ -261,7 +261,7 @@ async function generateLunrSource(timestamp) {
         const response = await axios
             .get(url, { auth, params: { final: "true" } })
             .catch((e) => console.log(e));
-        return response.data;
+        return response.data.filter((i) => (i.final));
     }
 
     async function getReadings(sectionId) {
@@ -280,7 +280,7 @@ async function generateLunrSource(timestamp) {
                 params: { label: "TRANSLATION" },
             })
             .catch((e) => console.log(e));
-        return response.data;
+        return response.data.filter((i) => (i.label === "TRANSLATION"))
     }
 }
 

--- a/script/generateDates.js
+++ b/script/generateDates.js
@@ -7,7 +7,7 @@ async function generateDates(timestamp) {
     console.log("start read and generate date info", moment().format("mm ss"));
     const config = loadConfig();
     const auth = config.auth;
-    const baseURL = `${config.options.repository}/tradition/${config.options.tradition_id}`;
+    const baseURL = `${config.options.repository}/${config.options.tradition_id}`;
     const outdir = `public/data/data_${timestamp}`;
     let wordHash = {};
     let dateList = [];
@@ -24,7 +24,7 @@ async function generateDates(timestamp) {
 
     // a possible api call to look up the reading, you can pass a begin and end node
     // we will start with getting the translation though -
-    //http://www.example.com/tradition/tradId/section/sectionId/lemmatext/
+    //http://www.example.com/tradId/section/sectionId/lemmatext/
 
     function writeDateList() {
         makeDirectory();
@@ -143,7 +143,7 @@ async function generateDates(timestamp) {
                     params: { label: "DATE" },
                 })
                 .catch((e) => console.log(e));
-            return response.data;
+            return response.data.filter((i) => (i.label === "DATE"));
         } catch (error) {
             console.log("error fetching all date annotations", error);
             return null;
@@ -158,7 +158,7 @@ async function generateDates(timestamp) {
                     params: { label: "DATEREF" },
                 })
                 .catch((e) => console.log(e));
-            return response.data;
+            return response.data.filter((i) => (i.label === "DATEREF"));
         } catch (error) {
             console.log("error fetching all date refs", error);
             return null;
@@ -173,7 +173,7 @@ async function generateDates(timestamp) {
                     params: { label: "DATING" },
                 })
                 .catch((e) => console.log(e));
-            return response.data;
+            return response.data.filter((i) => (i.label === "DATING"));
         } catch (error) {
             console.log("error fetching all datings", error);
             return null;
@@ -216,7 +216,7 @@ async function generateDates(timestamp) {
                     params: { label: "TRANSLATION" },
                 })
                 .catch((e) => console.log(e));
-            return response.data;
+            return response.data.filter((i) => (i.label === "TRANSLATION"));
         } catch (error) {
             console.log("error fetching translation for section", sectionId);
             return null;

--- a/script/generateLocationData.js
+++ b/script/generateLocationData.js
@@ -8,7 +8,7 @@ async function GenerateLocationData(timestamp) {
     const startTime = moment();
     console.log("started", startTime.format("hh:mm:ss"));
     const config = loadConfig();
-    const baseURL = `${config.options.repository}/tradition/${config.options.tradition_id}`;
+    const baseURL = `${config.options.repository}/${config.options.tradition_id}`;
     const auth = config.auth;
     const outdir = `public/data/data_${timestamp}`;
     const geoLocations = [];

--- a/script/generateLunrData.js
+++ b/script/generateLunrData.js
@@ -9,7 +9,7 @@ async function generateLunrSource(timestamp) {
     const startTime = moment();
     console.log("started", startTime.format("hh:mm:ss"));
     const config = loadConfig();
-    const baseURL = `${config.options.repository}/tradition/${config.options.tradition_id}`;
+    const baseURL = `${config.options.repository}/${config.options.tradition_id}`;
     const auth = config.auth;
     const outdir = `public/data/data_${timestamp}`;
     const lunrData = [];
@@ -176,7 +176,7 @@ async function generateLunrSource(timestamp) {
             sigil === "Lemma text"
                 ? (r) => r.is_lemma && !r.is_start && !r.is_end
                 : (r) =>
-                      r.witnesses.includes(sigil) && !r.is_start && !r.is_end;
+                    r.witnesses.includes(sigil) && !r.is_start && !r.is_end;
         const witReadings = readings.filter(filterCondition);
         witReadings.sort((first, second) => {
             return first.rank - second.rank;
@@ -244,7 +244,7 @@ async function generateLunrSource(timestamp) {
         const response = await axios
             .get(url, { auth, params: { final: "true" } })
             .catch((e) => console.log(e));
-        return response.data;
+        return response.data.filter((i) => (i.final));
     }
 
     async function getReadings(sectionId) {
@@ -263,7 +263,7 @@ async function generateLunrSource(timestamp) {
                 params: { label: "TRANSLATION" },
             })
             .catch((e) => console.log(e));
-        return response.data;
+        return response.data.filter((i) => (i.label === "TRANSLATION"));
     }
 }
 

--- a/script/generateManuscriptHtml.js
+++ b/script/generateManuscriptHtml.js
@@ -23,7 +23,7 @@ class DirectoriesRead {
 async function generateManuscriptHtml(timestamp) {
     console.log(`begin processing ${moment().format("mm:ss")}`);
     const config = loadConfig();
-    const baseURL = `${config.options.repository}/tradition/${config.options.tradition_id}`;
+    const baseURL = `${config.options.repository}/${config.options.tradition_id}`;
     const auth = config.auth;
     const sourcePath = "public/images/mss";
     const sigilLookup = [];

--- a/script/generateStore.js
+++ b/script/generateStore.js
@@ -11,7 +11,7 @@ async function generateStore(timestamp) {
     const startTime = moment();
     console.log("started", startTime.format("hh:mm:ss"));
     const config = loadConfig();
-    const baseURL = `${config.options.repository}/tradition/${config.options.tradition_id}`;
+    const baseURL = `${config.options.repository}/${config.options.tradition_id}`;
     const auth = config.auth;
     const outdir = `public/data/data_${timestamp}`;
     const lunrIndex = [];
@@ -178,7 +178,7 @@ async function generateStore(timestamp) {
         const response = await axios
             .get(url, { auth, params: { final: "true" } })
             .catch((e) => console.log(e));
-        return response.data;
+        return response.data.filter((i) => (i.final));
     }
 
     async function getReadings(sectionId) {
@@ -205,7 +205,7 @@ async function generateStore(timestamp) {
                 params: { label: "TRANSLATION" },
             })
             .catch((e) => console.log(e));
-        return response.data;
+        return response.data.filter((i) => (i.label === "TRANSLATION"));
     }
 
     async function getTitle(sectionId) {
@@ -216,7 +216,7 @@ async function generateStore(timestamp) {
                 params: { label: "TITLE" },
             })
             .catch((e) => console.log(e));
-        return response.data;
+        return response.data.filter((i) => (i.label === "TITLE"));
     }
 
     async function getPersons(sectionId) {
@@ -228,7 +228,7 @@ async function generateStore(timestamp) {
                     params: { label: "PERSONREF" },
                 })
                 .catch((e) => console.log(e));
-            return response.data;
+            return response.data.filter((i) => (i.label === "PERSONREF"));
         } catch (error) {
             console.log(`no person refs for section ${sectionId} `);
             return null;
@@ -241,7 +241,7 @@ async function generateStore(timestamp) {
             const response = await axios
                 .get(`${baseURL}/annotations?label=PERSON`, { auth })
                 .catch((e) => console.log(e));
-            return response;
+            return response.data.filter((i) => (i.label === "PERSON"));
         } catch (error) {
             console.log(error.message);
         }
@@ -253,7 +253,7 @@ async function generateStore(timestamp) {
             const response = await axios
                 .get(`${annotationURL}`, { auth, params: { label: "COMMENT" } })
                 .catch((e) => console.log(e));
-            return response.data;
+            return response.data.filter((i) => (i.label === "COMMENT"));
         } catch (error) {
             console.log(`no comments for section ${sectionId} `);
             return null;
@@ -269,7 +269,7 @@ async function generateStore(timestamp) {
                     params: { label: "PLACEREF" },
                 })
                 .catch((e) => console.log(e));
-            return response.data;
+            return response.data.filter((i) => (i.label === "PLACEREF"));
         } catch (error) {
             console.log(`no place refs for section ${sectionId} `);
             return null;
@@ -281,7 +281,7 @@ async function generateStore(timestamp) {
         const response = await axios
             .get(`${annotationURL}`, { auth, params: { label: "DATEREF" } })
             .catch((e) => console.log(e));
-        return response.data;
+        return response.data.filter((i) => (i.label === "DATEREF"));
     }
 
     function readingToHTML(reading) {
@@ -412,7 +412,7 @@ async function generateStore(timestamp) {
             sigil === "Lemma text"
                 ? (r) => r.is_lemma && !r.is_start && !r.is_end
                 : (r) =>
-                      r.witnesses.includes(sigil) && !r.is_start && !r.is_end;
+                    r.witnesses.includes(sigil) && !r.is_start && !r.is_end;
         const witReadings = readings.filter(filterCondition);
         witReadings.sort((first, second) => {
             return first.rank - second.rank;

--- a/script/generate_svgs.py
+++ b/script/generate_svgs.py
@@ -10,7 +10,7 @@ from requests.auth import HTTPBasicAuth
 
 def collect_tradition_data(options, auth=None):
     '''Iterate through the given tradition, saving an SVG  for each section into the necessary output directory.'''
-    baseurl = "%s/tradition/%s" % (options.repository, options.tradition_id.strip())
+    baseurl = "%s/%s" % (options.repository, options.tradition_id.strip())
 
     r = requests.get("%s/sections" % baseurl, auth=auth)
     r.raise_for_status()
@@ -42,7 +42,7 @@ def collect_section_data(options, section, outdir, auth=None):
         os.makedirs(sectiondir)
     except FileExistsError:
         pass
-    baseurl = "%s/tradition/%s/section/%s" % (options.repository, options.tradition_id.strip(), section.get('id'))
+    baseurl = "%s/%s/section/%s" % (options.repository, options.tradition_id.strip(), section.get('id'))
     # Collect the section dot and SVGify it
     dotparams = {
         'show_normal': 'true',


### PR DESCRIPTION
### In this PR
- Removes the `/tradition` path from the remote API paths;
- Adds filtering on the methods to fetch annotations with specific labels or other properties, since it seems that currently the API isn't processing the URL parameters.

### Notes
I wasn't sure if it would make more sense, if we're filtering anyway, to refactor the scripts a bit so that we're only calling the `/annotations` endpoint once and then using the different methods just to filter, or whether it was better to keep things more self-contained so that e.g. `getPlaces` etc. can be called in other contexts where they might not have the API response as input. Would be an easy enough change to implement I think but for now I went for minimal changes to the existing code.